### PR TITLE
Update KDE tray permission error

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -53,7 +53,10 @@ class FinishArgsCheck(Check):
             self.errors.add("finish-args-redundant-home-and-host")
 
         for own_name in fa["own-name"]:
-            if own_name.startswith("org.kde.StatusNotifierItem"):
+            if (
+                own_name.startswith("org.kde.StatusNotifierItem")
+                or own_name == "org.kde.*"
+            ):
                 self.errors.add("finish-args-broken-kde-tray-permission")
 
             if appid:


### PR DESCRIPTION
As of Qt 6.2 the tray works as expected without extra permissions. This version should be in all supported KDE runtimes.

Using org.kde.* is not a correct permission and is a security risk.

Closes #66