### PR TITLE
Allow Organic Maps beta channel to track latest upstream

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -896,6 +896,9 @@
     "org.gnome.Totem.Devel": {
         "module-totem-source-git-no-commit-or-tag": "This is the development version of Totem, tracking upstream"
     },
+    "app.organicmaps.desktop": {
+        "module-organicmaps-source-git-no-commit-or-tag": "This is the beta version of Organic Maps, tracking upstream"
+    },
     "org.fcitx.Fcitx5": {
         "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access"
     },


### PR DESCRIPTION
We pretend our master is good enough for testing by end users, so we would like to be able track upstream for flathub-beta channel.

Currently have error if commit is not mentioned:
https://buildbot.flathub.org/#/builders/26/builds/6014

This is the similar situation as https://github.com/flathub/flathub/issues/3588

@biodranik @barthalion