### PR TITLE
Fix tests

### DIFF
--- a/flatpak_builder_lint/builddir.py
+++ b/flatpak_builder_lint/builddir.py
@@ -68,7 +68,11 @@ def parse_metadata(ini: str) -> dict:
     if "sockets" in permissions:
         permissions["socket"] = permissions.pop("sockets")
 
-    if "x11" in permissions["socket"] and "fallback-x11" in permissions["socket"]:
+    if (
+        "sockets" in permissions
+        and "x11" in permissions["socket"]
+        and "fallback-x11" in permissions["socket"]
+    ):
         permissions["socket"].remove("x11")
 
     if "devices" in permissions:

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -32,11 +32,9 @@ def test_builddir_finish_args() -> None:
     }
 
     warnings = {
-        "finish-args-contains-both-x11-and-wayland",
         "finish-args-deprecated-shm",
         "finish-args-x11-without-ipc",
         "finish-args-redundant-device-all",
-        "finish-args-contains-both-x11-and-fallback",
     }
 
     ret = run_checks("tests/builddir/finish_args")


### PR DESCRIPTION
They were broken by b997423a39c77f9a173ba075b9b288a2d1f32f88

- x11-fallback is removed so it no longer appear in the output
- if permission is none, checking the value for a key turn it to a set, cause the test to fail. Reduce the side effect.