### PR TITLE
feat: add io.github.Archeb.opentrace with finish-args-flatpak-spawn-a…

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1480,6 +1480,9 @@
     "io.exodus.Exodus": {
         "flathub-json-modified-publish-delay": "extra-data"
     },
+    "io.github.Archeb.opentrace.metainfo": {
+        "finish-args-flatpak-spawn-access": "This app uses org.freedesktop.Flatpak to provide ability to run nexttrace with cap_net_raw, which is necessary for a traceroute app"
+    },
     "io.github.Fndroid.clash_for_windows": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
…ccess

This app uses org.freedesktop.Flatpak to provide ability to run nexttrace with cap_net_raw, which is necessary for a traceroute app.