### PR TITLE
exceptions: org.kde.gwenview: Add finish-args-unnecessary-xdg-data-access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1230,6 +1230,9 @@
     "org.kde.dolphin": {
         "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     },
+    "org.kde.gwenview": {
+        "finish-args-unnecessary-xdg-data-access": "required for access to Trash until Portal support is added"
+    },
     "org.kde.kate": {
         "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     },


### PR DESCRIPTION
See: https://github.com/flathub/org.kde.gwenview/pull/117