### PR TITLE
add io.itch.ksylvestre.MightyGrepDemo exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1057,6 +1057,9 @@
     "com.vscodium.codium-insiders": {
         "finish-args-flatpak-spawn-access": "needed to spawn several tools and command from host like podman, toolbox, compilers, etc"
     },
+    "dev.ksylvestre.MightyGrepDemo": {
+        "finish-args-flatpak-spawn-access": "needed for user specified 'Open in editor' and 'Open file location' commands"
+    },
     "dev.boxi.Boxi": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1057,7 +1057,7 @@
     "com.vscodium.codium-insiders": {
         "finish-args-flatpak-spawn-access": "needed to spawn several tools and command from host like podman, toolbox, compilers, etc"
     },
-    "dev.ksylvestre.MightyGrepDemo": {
+    "io.itch.ksylvestre.MightyGrepDemo": {
         "finish-args-flatpak-spawn-access": "needed for user specified 'Open in editor' and 'Open file location' commands"
     },
     "dev.boxi.Boxi": {


### PR DESCRIPTION
MightyGrep Demo needs these permissions:

- `finish-args-flatpak-spawn-access`: needed to create processes for user specified 'Open in editor' and 'Open file location' commands. The editor command is used in the context of jumping to a match found ex: gvim "$filepath" +$line