### PR TITLE
Add a check for low quality categories

### DIFF
--- a/tests/builddir/desktop-file/files/share/applications/com.github.flathub_infra.desktop-file.desktop
+++ b/tests/builddir/desktop-file/files/share/applications/com.github.flathub_infra.desktop-file.desktop
@@ -9,3 +9,4 @@ Icon=org.flathub.foo
 Terminal=false
 Type=Application
 Hidden=true
+Categories=GTK;Qt

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -108,6 +108,8 @@ def test_builddir_desktop_file() -> None:
         "desktop-file-exec-has-flatpak-run"
     }
     found_errors = set(ret["errors"])
+    found_warnings = set(ret["warnings"])
 
+    assert "desktop-file-low-quality-category" in found_warnings
     for err in errors:
         assert err in found_errors


### PR DESCRIPTION
See https://github.com/ximion/appstream/issues/577

`Categories=GTK;Qt;` will be caught but not `Categories=GTK;Qt;Network;` because there was at least one item not in `block`.