### PR TITLE
metainfo: Drop flathub.json handling and rework

### DIFF
--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -40,6 +40,20 @@ class MetainfoCheck(Check):
         ) in ("desktop", "desktop-application"):
             self.errors.add("appstream-missing-icon-file")
 
+        if not appstream.is_developer_name_present(appstream_path):
+            self.warnings.add("appstream-missing-developer-name")
+        if not appstream.is_project_license_present(appstream_path):
+            self.warnings.add("appstream-missing-project-license")
+        # for mypy
+        name = appstream.name(appstream_path)
+        summary = appstream.summary(appstream_path)
+        if name is not None and len(name) > 20:
+            self.warnings.add("appstream-name-too-long")
+        if summary is not None and len(summary) > 35:
+            self.warnings.add("appstream-summary-too-long")
+        if not appstream.check_caption(appstream_path):
+            self.warnings.add("appstream-screenshot-missing-caption")
+
         for metainfo_dir in metainfo_dirs:
             for ext in metainfo_exts:
                 metainfo_dirext = f"{metainfo_dir}/{appid}{ext}"
@@ -53,20 +67,6 @@ class MetainfoCheck(Check):
                 self.errors.add("appstream-metainfo-missing")
 
             if metainfo_path is not None:
-                if not appstream.is_developer_name_present(appstream_path):
-                    self.warnings.add("appstream-missing-developer-name")
-                if not appstream.is_project_license_present(appstream_path):
-                    self.warnings.add("appstream-missing-project-license")
-                # for mypy
-                name = appstream.name(appstream_path)
-                summary = appstream.summary(appstream_path)
-                if name is not None and len(name) > 20:
-                    self.warnings.add("appstream-name-too-long")
-                if summary is not None and len(summary) > 35:
-                    self.warnings.add("appstream-summary-too-long")
-                if not appstream.check_caption(appstream_path):
-                    self.warnings.add("appstream-screenshot-missing-caption")
-
                 appinfo_validation = appstream.validate(metainfo_path)
                 if appinfo_validation["returncode"] != 0:
                     self.errors.add("appstream-failed-validation")

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -17,7 +17,23 @@ class MetainfoCheck(Check):
         metainfo_exts = [".appdata.xml", ".metainfo.xml"]
         metainfo_path = None
 
-        is_baseapp = appid.endswith(".BaseApp")
+        if appid.endswith(".BaseApp"):
+            return
+
+        if not os.path.exists(appstream_path):
+            self.errors.add("appstream-missing-appinfo-file")
+            return
+
+        if len(appstream.components(appstream_path)) != 1:
+            self.errors.add("appstream-multiple-components")
+            return
+
+        if appstream.component_type(appstream_path) not in (
+            "desktop",
+            "desktop-application",
+            "console-application",
+        ):
+            return
 
         for metainfo_dir in metainfo_dirs:
             for ext in metainfo_exts:
@@ -46,18 +62,16 @@ class MetainfoCheck(Check):
                 if not appstream.check_caption(appstream_path):
                     self.warnings.add("appstream-screenshot-missing-caption")
 
-                if not is_baseapp:
-                    appinfo_validation = appstream.validate(metainfo_path)
-                    if appinfo_validation["returncode"] != 0:
-                        self.errors.add("appstream-failed-validation")
-                        for err in appinfo_validation["stderr"].split(":", 1)[1:]:
-                            self.appstream.add(err.strip())
-                        for out in appinfo_validation["stdout"].splitlines()[1:]:
-                            self.appstream.add(re.sub("^\u2022", "", out).strip())
+                appinfo_validation = appstream.validate(metainfo_path)
+                if appinfo_validation["returncode"] != 0:
+                    self.errors.add("appstream-failed-validation")
+                    for err in appinfo_validation["stderr"].split(":", 1)[1:]:
+                        self.appstream.add(err.strip())
+                    for out in appinfo_validation["stdout"].splitlines()[1:]:
+                        self.appstream.add(re.sub("^\u2022", "", out).strip())
 
         if not os.path.exists(icon_path):
-            if not is_baseapp:
-                self.errors.add("appstream-missing-icon-file")
+            self.errors.add("appstream-missing-icon-file")
 
     def check_build(self, path: str) -> None:
         appid = builddir.infer_appid(path)
@@ -67,17 +81,10 @@ class MetainfoCheck(Check):
         metadata = builddir.get_metadata(path)
         if not metadata:
             return
-        is_extension = metadata.get("extension")
+        if metadata.get("extension"):
+            return
 
         self._validate(f"{path}", appid)
-
-        if is_extension:
-            self.errors.discard("appstream-failed-validation")
-            self.errors.discard("appstream-missing-icon-file")
-
-        appstream_path = f"{path}/files/share/app-info/xmls/{appid}.xml.gz"
-        if os.path.exists(appstream_path) and appstream.is_console(appstream_path):
-            self.errors.discard("appstream-missing-icon-file")
 
     def check_repo(self, path: str) -> None:
         self._populate_ref(path)
@@ -90,7 +97,5 @@ class MetainfoCheck(Check):
             ret = ostree.extract_subpath(path, ref, "/", tmpdir)
             if ret["returncode"] != 0:
                 raise RuntimeError("Failed to extract ostree repo")
-            appstream_path = f"{tmpdir}/files/share/app-info/xmls/{appid}.xml.gz"
+
             self._validate(tmpdir, appid)
-            if os.path.exists(appstream_path) and appstream.is_console(appstream_path):
-                self.errors.discard("appstream-missing-icon-file")

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -67,12 +67,12 @@ class MetainfoCheck(Check):
             self.errors.add("appstream-metainfo-missing")
             return
 
-        appinfo_validation = appstream.validate(metainfo_path)
-        if appinfo_validation["returncode"] != 0:
+        metainfo_validation = appstream.validate(metainfo_path)
+        if metainfo_validation["returncode"] != 0:
             self.errors.add("appstream-failed-validation")
-        for err in appinfo_validation["stderr"].split(":", 1)[1:]:
+        for err in metainfo_validation["stderr"].split(":", 1)[1:]:
             self.appstream.add(err.strip())
-        for out in appinfo_validation["stdout"].splitlines()[1:]:
+        for out in metainfo_validation["stdout"].splitlines()[1:]:
             self.appstream.add(re.sub("^\u2022", "", out).strip())
 
     def check_build(self, path: str) -> None:

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -35,6 +35,11 @@ class MetainfoCheck(Check):
         ):
             return
 
+        if not os.path.exists(icon_path) and appstream.component_type(
+            appstream_path
+        ) in ("desktop", "desktop-application"):
+            self.errors.add("appstream-missing-icon-file")
+
         for metainfo_dir in metainfo_dirs:
             for ext in metainfo_exts:
                 metainfo_dirext = f"{metainfo_dir}/{appid}{ext}"
@@ -69,9 +74,6 @@ class MetainfoCheck(Check):
                         self.appstream.add(err.strip())
                     for out in appinfo_validation["stdout"].splitlines()[1:]:
                         self.appstream.add(re.sub("^\u2022", "", out).strip())
-
-        if not os.path.exists(icon_path):
-            self.errors.add("appstream-missing-icon-file")
 
     def check_build(self, path: str) -> None:
         appid = builddir.infer_appid(path)

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -65,32 +65,13 @@ def test_builddir_flathub_json() -> None:
     assert warnings.issubset(found_warnings)
 
 def test_builddir_baseapp() -> None:
-    errors = {
-        "appstream-missing-appinfo-file",
-        "appstream-metainfo-missing"
-    }
-
     ret = run_checks("tests/builddir/baseapp")
-    found_errors = set(ret["errors"])
-
-    assert errors == found_errors
 
 def test_builddir_extension() -> None:
-    errors = {
-        "appstream-missing-appinfo-file",
-        "appstream-metainfo-missing"
-    }
-
     ret = run_checks("tests/builddir/extension")
-    found_errors = set(ret["errors"])
-
-    assert errors == found_errors
 
 def test_builddir_console() -> None:
-    errors = {
-        "appstream-metainfo-missing",
-        "finish-args-not-defined"
-    }
+    errors = {"finish-args-not-defined"}
 
     ret = run_checks("tests/builddir/console")
     found_errors = set(ret["errors"])


### PR DESCRIPTION
`flathub.json` has never worked unless it was installed in builddir. 

I don't see a reason to keep it and complicate things, considering metainfo checks can be skipped based on the heuristics alone and anything not skipped ends up being a few regular desktop-applications.

Now they should be checked, but `flathub.json` gives them a silent way out of the linter's metainfo checks without being gated by exceptions.

Any legitimate desktop-applications needing to use `skip-appstream-check` or `skip-icon-check` should apply for the corresponding linter exception. I can probably ease some of it by mass adding some legitimate exceptions.

The state with this PR:

- Extensions/baseapps skips all checks here early
- No check is done unless `type=desktop, desktop-application, console-application`
- Icon check is done only on `type==desktop,desktop-application`
- Rest ie. `desktop, desktop-application, console-application` goes through appinfo + metainfo checks and validation


Draft because I need to test it locally + discussions.


I can probably create a version of this PR with `flathub_json` included if need be.