### PR TITLE
org.libreoffice.LibreOffice: finish-args-unnecessary-xdg-config-access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1747,5 +1747,8 @@
     },
     "io.liri.BaseApp": {
         "*": "This is a baseapp"
+    },
+    "org.libreoffice.LibreOffice": {
+        "linter-error": "deliberate finish-args-unnecessary-xdg-config-access violations"
     }
 }


### PR DESCRIPTION
As discussed in the mailing list thread starting at <https://lists.freedesktop.org/archives/flatpak/2023-December/002328.html> "Unhelpful flathub finish-args-unnecessary-xdg-config-access error", org.libreoffice.LibreOffice deliberately has

>         "--filesystem=xdg-config/gtk-3.0",

(once added with
<https://github.com/flathub/org.libreoffice.LibreOffice/commit/e2376fbfdb12b9fca44c9413d08f2ed35b7b3d2f> "Adding access to gtk-3.0 config, mainly to give access to bookmarks for the file picker") and

>         "--filesystem=xdg-config/fontconfig:ro",

(once added with
<https://github.com/flathub/org.libreoffice.LibreOffice/commit/c80b412af7ec1d15b49c64ec6590450e9bacd3f2> "fix missing user-installed fonts"), but which started to cause

> {
>     "errors": [
>         "finish-args-unnecessary-xdg-config-access"
>     ]
> }

build failures now.