### PR TITLE
Remove seperate extension key

### DIFF
--- a/flatpak_builder_lint/appstream.py
+++ b/flatpak_builder_lint/appstream.py
@@ -54,12 +54,6 @@ def component_type(path: str) -> str:
     return str(components(path)[0].attrib.get("type"))
 
 
-def is_console(path: str) -> bool:
-    if component_type(path) == "console-application":
-        return True
-    return False
-
-
 def name(path: str) -> Optional[str]:
     for name in parse_xml(path).findall("component/name"):
         if not name.attrib.get(r"{http://www.w3.org/XML/1998/namespace}lang"):

--- a/flatpak_builder_lint/builddir.py
+++ b/flatpak_builder_lint/builddir.py
@@ -38,9 +38,6 @@ def parse_metadata(ini: str) -> dict:
         tags = [x for x in metadata["tags"].split(";") if x]
         metadata["tags"] = tags
 
-    if "ExtensionOf" in parser:
-        metadata["extension"] = "yes"
-
     permissions: dict = defaultdict(set)
 
     if "Context" in parser:

--- a/flatpak_builder_lint/checks/desktop.py
+++ b/flatpak_builder_lint/checks/desktop.py
@@ -133,7 +133,7 @@ class DesktopfileCheck(Check):
         metadata = builddir.get_metadata(path)
         if not metadata:
             return
-        if metadata.get("extension"):
+        if metadata.get("type", False) != "application":
             return
 
         self._validate(f"{path}", appid)

--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -127,16 +127,17 @@ class FinishArgsCheck(Check):
         if not metadata:
             return
 
+        if metadata.get("type", False) != "application":
+            return
+
         appid = metadata.get("name")
         if isinstance(appid, str):
             is_baseapp = appid.endswith(".BaseApp")
         else:
             is_baseapp = False
 
-        is_extension = metadata.get("extension")
-
         permissions = metadata.get("permissions", {})
-        if not permissions and not (is_baseapp or is_extension):
+        if not permissions and not is_baseapp:
             self.errors.add("finish-args-not-defined")
             return
 

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -82,7 +82,7 @@ class MetainfoCheck(Check):
         metadata = builddir.get_metadata(path)
         if not metadata:
             return
-        if metadata.get("extension"):
+        if metadata.get("type", False) != "application":
             return
 
         self._validate(f"{path}", appid)


### PR DESCRIPTION
At the time I didn't realise that extensions are also started with `[Runtime]`, the current one handles skips for both actual runtimes and extensions too.


This makes it possible to use on runtimes too. I tested it on a local build and repo of the KDE 6.6 runtime and all checks passed.