### PR TITLE
Command line package exceptions for se.emijoh.mpw

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1190,6 +1190,10 @@
     "org.freedesktop.appstream-glib": {
         "flathub-json-skip-appstream-check": "It is a command line package"
     },
+    "se.emijoh.mpw": {
+        "flathub-json-skip-appstream-check": "It is a command line package",
+	"finish-args-not-defined": "It is a command line package"
+    },
     "org.freedesktop.LinuxAudio.BaseExtension": {
         "toplevel-no-command": "It is a base app without anything to run",
         "finish-args-not-defined": "It is a base app without anything to run",

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1191,7 +1191,6 @@
         "flathub-json-skip-appstream-check": "It is a command line package"
     },
     "se.emijoh.mpw": {
-        "flathub-json-skip-appstream-check": "It is a command line package",
 	"finish-args-not-defined": "It is a command line package"
     },
     "org.freedesktop.LinuxAudio.BaseExtension": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1191,7 +1191,7 @@
         "flathub-json-skip-appstream-check": "It is a command line package"
     },
     "se.emijoh.mpw": {
-	"finish-args-not-defined": "It is a command line package"
+        "finish-args-not-defined": "It is a command line package"
     },
     "org.freedesktop.LinuxAudio.BaseExtension": {
         "toplevel-no-command": "It is a base app without anything to run",


### PR DESCRIPTION
Based on other exceptions for these liner I get the impression they are not applicable to terminal application like `se.emijoh.mpw`

https://github.com/flathub/se.emijoh.mpw/pull/6