### PR TITLE
Block wildcard access of bus names in well-known namespace

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -69,6 +69,20 @@ class FinishArgsCheck(Check):
                     own_name.startswith(appid) and own_name[len(appid)] == "."
                 ):
                     self.errors.add("finish-args-unnecessary-appid-own-name")
+            if own_name == "org.freedesktop.*":
+                self.errors.add("finish-args-wildcard-freedesktop-own-name")
+            if own_name == "org.gnome.*":
+                self.errors.add("finish-args-wildcard-gnome-own-name")
+            if own_name == "org.kde.*":
+                self.errors.add("finish-args-wildcard-kde-own-name")
+
+        for talk_name in finish_args["talk-name"]:
+            if talk_name == "org.freedesktop.*":
+                self.errors.add("finish-args-wildcard-freedesktop-talk-name")
+            if talk_name == "org.gnome.*":
+                self.errors.add("finish-args-wildcard-gnome-talk-name")
+            if talk_name == "org.kde.*":
+                self.errors.add("finish-args-wildcard-kde-talk-name")
 
         if (
             "xdg-config/autostart" in finish_args["filesystem"]

--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -75,6 +75,8 @@ class FinishArgsCheck(Check):
                 self.errors.add("finish-args-wildcard-gnome-own-name")
             if own_name == "org.kde.*":
                 self.errors.add("finish-args-wildcard-kde-own-name")
+            if own_name.startswith("org.freedesktop.portal."):
+                self.errors.add("finish-args-portal-own-name")
 
         for talk_name in finish_args["talk-name"]:
             if talk_name == "org.freedesktop.*":
@@ -83,6 +85,8 @@ class FinishArgsCheck(Check):
                 self.errors.add("finish-args-wildcard-gnome-talk-name")
             if talk_name == "org.kde.*":
                 self.errors.add("finish-args-wildcard-kde-talk-name")
+            if talk_name.startswith("org.freedesktop.portal."):
+                self.errors.add("finish-args-portal-talk-name")
 
         if (
             "xdg-config/autostart" in finish_args["filesystem"]

--- a/tests/builddir/finish_args/metadata
+++ b/tests/builddir/finish_args/metadata
@@ -7,6 +7,7 @@ devices=all;shm;
 filesystems=home;xdg-data;xdg-config/autostart;host;xdg-data/foo:create;
 
 [Session Bus Policy]
+org.freedesktop.portal.*=talk
 org.freedesktop.*=talk
 org.gnome.*=own
 org.kde.*=own

--- a/tests/builddir/finish_args/metadata
+++ b/tests/builddir/finish_args/metadata
@@ -7,6 +7,9 @@ devices=all;shm;
 filesystems=home;xdg-data;xdg-config/autostart;host;xdg-data/foo:create;
 
 [Session Bus Policy]
+org.freedesktop.*=talk
+org.gnome.*=own
+org.kde.*=own
 org.freedesktop.Flatpak=talk
 org.flathub.finish_args=own
 org.kde.StatusNotifierItem=own

--- a/tests/manifests/finish_args.json
+++ b/tests/manifests/finish_args.json
@@ -20,6 +20,7 @@
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.kde.*",
         "--own-name=org.gnome.*",
-        "--talk-name=org.freedesktop.*"
+        "--talk-name=org.freedesktop.*",
+        "--own-name=org.freedesktop.portal.Foo"
     ]
 }

--- a/tests/manifests/finish_args.json
+++ b/tests/manifests/finish_args.json
@@ -17,6 +17,9 @@
         "--socket=x11",
         "--socket=fallback-x11",
         "--talk-name=org.gtk.vfs",
-        "--talk-name=org.freedesktop.Flatpak"
+        "--talk-name=org.freedesktop.Flatpak",
+        "--talk-name=org.kde.*",
+        "--own-name=org.gnome.*",
+        "--talk-name=org.freedesktop.*"
     ]
 }

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -24,6 +24,9 @@ def test_builddir_finish_args() -> None:
         "finish-args-redundant-home-and-host",
         "finish-args-unnecessary-appid-own-name",
         "finish-args-unnecessary-xdg-data-access",
+        "finish-args-wildcard-freedesktop-talk-name",
+        "finish-args-wildcard-gnome-own-name",
+        "finish-args-wildcard-kde-own-name",
     }
 
     warnings = {

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -27,6 +27,7 @@ def test_builddir_finish_args() -> None:
         "finish-args-wildcard-freedesktop-talk-name",
         "finish-args-wildcard-gnome-own-name",
         "finish-args-wildcard-kde-own-name",
+        "finish-args-portal-talk-name",
     }
 
     warnings = {

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -71,6 +71,7 @@ def test_manifest_finish_args() -> None:
         "finish-args-wildcard-freedesktop-talk-name",
         "finish-args-wildcard-gnome-own-name",
         "finish-args-wildcard-kde-talk-name",
+        "finish-args-portal-own-name",
     }
 
     warnings = {

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -29,6 +29,7 @@ def test_manifest_toplevel() -> None:
 
     assert "toplevel-no-command" not in found_errors
 
+
 def test_manifest_appid() -> None:
     errors = {
         "appid-filename-mismatch",
@@ -67,6 +68,9 @@ def test_manifest_finish_args() -> None:
         "finish-args-redundant-home-and-host",
         "finish-args-unnecessary-appid-own-name",
         "finish-args-unnecessary-xdg-data-access",
+        "finish-args-wildcard-freedesktop-talk-name",
+        "finish-args-wildcard-gnome-own-name",
+        "finish-args-wildcard-kde-talk-name",
     }
 
     warnings = {
@@ -94,6 +98,7 @@ def test_manifest_finish_args_issue_33() -> None:
     found_errors = set(ret["errors"])
     assert "finish-args-unnecessary-appid-own-name" in found_errors
 
+
 def test_manifest_finish_args_empty() -> None:
     ret = run_checks("tests/manifests/finish_args_empty.json")
     found_errors = set(ret["errors"])
@@ -102,6 +107,7 @@ def test_manifest_finish_args_empty() -> None:
     ret = run_checks("tests/manifests/finish_args_missing.json")
     found_errors = set(ret["errors"])
     assert "finish-args-not-defined" in found_errors
+
 
 def test_manifest_modules() -> None:
     errors = {


### PR DESCRIPTION
Alternative to https://github.com/flathub-infra/flatpak-builder-lint/pull/114, closes https://github.com/flathub-infra/flatpak-builder-lint/pull/114, blocks in both `own-name` and `talk-name`.

List based on ones that are most likely to find their way in manifests and can potentially give widespread access. If there are more, please comment below.

This can be reused to block the pattern in https://github.com/flathub-infra/flatpak-builder-lint/issues/178 too

I don't see a generic method to block `*` because a bunch of legitimate ones can end in `*` The third component or ones after that are reserved for applications, e.g. `org.gnome.evolution.*`


Closes https://github.com/flathub-infra/flatpak-builder-lint/issues/178