### PR TITLE
exceptions: info.cemu.Cemu: Add finish-args-unnecessary-xdg-data-access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7,6 +7,9 @@
     "org.flathub.exceptions_wildcard": {
         "*": "ignore all errors and warnings"
     },
+    "info.cemu.Cemu": {
+        "finish-args-unnecessary-xdg-data-access": "the app allows the user to create desktop files to launch games directly"
+    },
     "page.codeberg.libre_menu_editor.LibreMenuEditor": {
         "finish-args-unnecessary-xdg-data-access": "this program needs write-access to xdg-data/applications and read-access to xdg-data/flatpak"
     },


### PR DESCRIPTION
Cemu allows the user to create desktop files to launch games directly.
~~Though it currently creates files that try to `Exec=/app/bin/Cemu`: https://github.com/flathub/info.cemu.Cemu/pull/106~~