### PR TITLE
Initial import of exceptions for legacy StatusNotifier usage

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1721,6 +1721,24 @@
     "app.drey.KeyRack": {
         "finish-args-unnecessary-xdg-data-access": "the app predates this linter rule"
     },
+    "com.discordapp.Discord": {
+        "finish-args-wildcard-kde-own-name": "Initial import, outdated Electron, still uses legacy StatusNotifier implementation"
+    },
+    "com.discordapp.DiscordCanary": {
+        "finish-args-wildcard-kde-own-name": "Initial import, outdated Electron, still uses legacy StatusNotifier implementation"
+    },
+    "com.hunterwittenborn.Celeste": {
+        "finish-args-wildcard-kde-own-name": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation"
+    },
+    "org.tribler.Tribler": {
+        "finish-args-wildcard-kde-own-name": "Initial import, Qsystemtrayicon still uses legacy StatusNotifier implementation"
+    },
+    "com.dropbox.Client": {
+        "finish-args-wildcard-kde-own-name": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation"
+    },
+    "us.zoom.Zoom": {
+        "finish-args-wildcard-kde-own-name": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation"
+    },
     "com.riverbankcomputing.PyQt.BaseApp": {
         "*": "This is a baseapp"
     },


### PR DESCRIPTION
```
requires --own-name='org.kde.*' under flatpak

Only handles maintained applications that had activity in the past year

Zoom: https://github.com/flathub/us.zoom.Zoom/pull/416
Discord: https://github.com/flathub/com.discordapp.Discord/issues/324
DiscordCanary: https://github.com/flathub/com.discordapp.DiscordCanary/issues/78
Celeste: https://github.com/flathub/com.hunterwittenborn.Celeste/pull/35
Tribler: https://github.com/flathub/org.tribler.Tribler/pull/10
Dropbox: https://github.com/flathub/com.dropbox.Client/pull/318
```




Depends on https://github.com/flathub-infra/flatpak-builder-lint/pull/259