### PR TITLE
Relax icon key value check to allow values flatpak exports

### DIFF
--- a/flatpak_builder_lint/checks/desktop.py
+++ b/flatpak_builder_lint/checks/desktop.py
@@ -84,7 +84,9 @@ class DesktopfileCheck(Check):
                     icon = d["Desktop Entry"]["Icon"]
                     if not len(icon) > 0:
                         self.errors.add("desktop-file-icon-key-empty")
-                    if len(icon) > 0 and icon != appid:
+                    if len(icon) > 0 and not re.match(
+                        rf"^{appid}([-.].*)?$", f"{icon}"
+                    ):
                         self.errors.add("desktop-file-icon-key-wrong-value")
                 except KeyError:
                     self.errors.add("desktop-file-icon-key-absent")


### PR DESCRIPTION
Also ignore extension suffix as they are supposed to be handled by the icon lookup implementation and seems a bit harsh