### PR TITLE
Add check for uncessary gamescope permission

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -57,6 +57,8 @@ class FinishArgsCheck(Check):
                     self.errors.add(f"finish-args-reserved-{resv_dir}")
             if fs.startswith("/home") or fs.startswith("/var/home"):
                 self.errors.add("finish-args-absolute-home-path")
+            if fs.startswith("xdg-run/gamescope-"):
+                self.errors.add("finish-args-unnecessary-gamescope")
 
         if "home" in finish_args["filesystem"] and "host" in finish_args["filesystem"]:
             self.errors.add("finish-args-redundant-home-and-host")

--- a/tests/manifests/finish_args.json
+++ b/tests/manifests/finish_args.json
@@ -17,6 +17,7 @@
         "--socket=x11",
         "--socket=fallback-x11",
         "--talk-name=org.gtk.vfs",
-        "--talk-name=org.freedesktop.Flatpak"
+        "--talk-name=org.freedesktop.Flatpak",
+        "--filesystem=xdg-run/gamescope-0:ro"
     ]
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -67,6 +67,7 @@ def test_manifest_finish_args() -> None:
         "finish-args-redundant-home-and-host",
         "finish-args-unnecessary-appid-own-name",
         "finish-args-unnecessary-xdg-data-access",
+        "finish-args-unnecessary-gamescope"
     }
 
     warnings = {


### PR DESCRIPTION
The correct way to use gamescope is simply to run:

    gamescope --expose-wayland flatpak run ...