### PR TITLE
Print a link to docs when there are errors or warnings

### DIFF
--- a/flatpak_builder_lint/cli.py
+++ b/flatpak_builder_lint/cli.py
@@ -163,6 +163,11 @@ def main() -> int:
 
         output = json.dumps(results, indent=4)
         print(output)
+        if len(output) != 0:
+            print(
+                "\nPlease consult the documentation at"
+                " https://docs.flathub.org/docs/for-app-authors/linter"
+            )
 
     sys.exit(exit_code)
 


### PR DESCRIPTION
I think not a lot of existing maintainers know that there are docs here, so linking it should make it easier to reach docs from the buildbot interface.

Eg. https://github.com/flathub-infra/flatpak-builder-lint/issues/270