### PR TITLE
Add a check to find if exportable icons exist

### DIFF
--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -107,6 +107,7 @@ def test_builddir_quality_guidelines() -> None:
     errors = {
         "appstream-missing-developer-name",
         "appstream-missing-project-license",
+        "no-exportable-icon-installed",
     }
     warnings = {
         "appstream-name-too-long",


### PR DESCRIPTION
```
This goes through icons installed in `/app/share/icons/hicolor` and
checks if any icons matching appid patterns that flatpak exports are
installed. If not return an error because without any icons exported
the icon referenced in desktop file won't be found and appear as empty
in DE overview.

This is seperate from the icon generated by appstream in app-info
because

- appinfo icons are not used by desktop files and flatpak does not
  export them
- it may happen that appstream compose created an icon and named it
  using FLATPAK_ID when no such icon with the correct filename was
  actually installed. The end result is, the flatpak ends up with no
  exportable icons
```

Eg. of this happening Kdevelop as of this commit https://github.com/flathub/org.kde.kdevelop/commit/9369b16e4011de25a867c512c27f2319f7b4fde4

<details>

<summary>  Current state of kdevelop </summary>

```sh
→ tree ~/.local/share/flatpak/app/org.kde.kdevelop/current/active/files/share/icons 
/home/bbhtt/.local/share/flatpak/app/org.kde.kdevelop/current/active/files/share/icons
└── hicolor
    ├── 1024x1024
    │   └── apps
    │       └── kdevelop.png
    ├── 128x128
    │   └── apps
    │       ├── bazaar.png
    │       ├── clazy.png
    │       ├── cmake.png
    │       ├── cppcheck.png
    │       ├── kdevelop.png
    │       └── okteta.png
    ├── 16x16
    │   ├── actions
    │   │   └── breakpoint.png
    │   └── apps
    │       ├── cmake.png
    │       ├── github-forked.png
    │       ├── github-private.png
    │       ├── github-repo.png
    │       ├── kdevelop.png
    │       ├── kdevgh.png
    │       └── okteta.png
    ├── 22x22
    │   ├── actions
    │   │   └── breakpoint.png
    │   └── apps
    │       └── okteta.png
    ├── 256x256
    │   └── apps
    │       └── kdevelop.png
    ├── 32x32
    │   ├── actions
    │   │   └── breakpoint.png
    │   └── apps
    │       ├── cmake.png
    │       ├── kdevelop.png
    │       ├── kdevgh.png
    │       └── okteta.png
    ├── 48x48
    │   └── apps
    │       ├── kdevelop.png
    │       └── okteta.png
    ├── 512x512
    │   └── apps
    │       └── kdevelop.png
    ├── 64x64
    │   └── apps
    │       ├── cmake.png
    │       ├── kdevelop.png
    │       └── okteta.png
    ├── icon-theme.cache
    └── scalable
        ├── actions
        │   └── breakpoint.svg
        └── apps
            ├── git.svg
            ├── kdevelop.svg
            └── qtlogo.svg

26 directories, 34 files
╭─bbhtt@fedora in ~ took 5ms
→ tree ~/.local/share/flatpak/app/org.kde.kdevelop/current/active/files/share/app-info 
/home/bbhtt/.local/share/flatpak/app/org.kde.kdevelop/current/active/files/share/app-info
├── icons
│   └── flatpak
│       ├── 128x128
│       │   └── org.kde.kdevelop.png
│       └── 64x64
│           └── org.kde.kdevelop.png
└── xmls
    ├── io.qt.qtwebengine.BaseApp.xml.gz
    └── org.kde.kdevelop.xml.gz
```

</details>