### PR TITLE
Add exception to io.kapsa.drive; Allow to setup FUSE network mount - S3Drive

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1716,6 +1716,9 @@
     "io.github.dvlv.boxbuddyrs": {
         "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host"
     },
+    "io.kapsa.drive": {
+        "finish-args-flatpak-spawn-access": "Required to spawn fusermount3 in order to run FUSE mount on a host system"
+    },
     "com.calibre_ebook.calibre": {
         "finish-args-unnecessary-xdg-data-access": "Needs direct trash access, doesn't use portal"
     },


### PR DESCRIPTION
Hi,

We would appreciate if you can review this exception for our app (https://flathub.org/apps/io.kapsa.drive).

One of our functionalities is to setup FUSE mount on the host system and we've got it running in this pull request: https://github.com/flathub/io.kapsa.drive/pull/30 however build fails (https://buildbot.flathub.org/#/builders/6/builds/96828) due to: 
```
{
    "errors": [
        "finish-args-flatpak-spawn-access"
    ]
}
```

hence our exception request.

![Screenshot from 2024-01-30 23-37-24](https://github.com/flathub-infra/flatpak-builder-lint/assets/7759113/270baa3b-cdde-4e27-950e-6088892de303)
![Screenshot from 2024-01-30 23-37-44](https://github.com/flathub-infra/flatpak-builder-lint/assets/7759113/4ea4ee3d-87f5-4ecf-aa6b-f351d39caf37)

Thanks !


