### PR TITLE
exceptions: Add com.nextcloud.desktopclient.nextcloud

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1404,6 +1404,9 @@
     "com.netease.CloudMusic": {
         "flathub-json-modified-publish-delay": "extra-data"
     },
+    "com.nextcloud.desktopclient.nextcloud": {
+        "desktop-file-failed-validation": "the validation tool is not exactly conformant yet as Implements values are allowed"
+    },
     "com.nordpass.NordPass": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
The desktop file contains the "org.freedesktop.CloudProviders" group defined in "Implements" which is allowed by the spec.

A fix to the desktop file validator has been provided in https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/merge_requests/21