### PR TITLE
exceptions: add kde-own-name to com.synology.SynologyDrive

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1444,7 +1444,8 @@
         "flathub-json-modified-publish-delay": "extra-data"
     },
     "com.synology.SynologyDrive": {
-        "flathub-json-modified-publish-delay": "extra-data"
+        "flathub-json-modified-publish-delay": "extra-data",
+        "finish-args-wildcard-kde-own-name": "Still uses legacy StatusNotifier implementation"
     },
     "com.syntevo.SmartGit": {
         "flathub-json-modified-publish-delay": "extra-data"


### PR DESCRIPTION
The Synology Drive client still uses legacy tray icons, therefore this MR adds the `finish-args-wildcard-kde-own-name` exception to make it pass the linter again.

Let me know if I missed something. Thanks in advance!