### PR TITLE
Error and stop on missing component tag in metainfo

### DIFF
--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -45,7 +45,10 @@ class MetainfoCheck(Check):
                 self.appstream.add(err.strip())
 
             stdout: List[str] = list(
-                filter(None, metainfo_validation["stdout"].splitlines()[:-1])
+                filter(
+                    lambda x: x.startswith(("E:", "W:")),
+                    metainfo_validation["stdout"].splitlines()[:-1],
+                )
             )
             for out in stdout:
                 self.appstream.add(out.strip())

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -52,6 +52,10 @@ class MetainfoCheck(Check):
 
         component = appstream.parse_xml(metainfo_path).xpath("/component")
 
+        if not component:
+            self.errors.add("metainfo-missing-component-tag")
+            return
+
         if component[0].attrib.get("type") is None:
             self.errors.add("metainfo-missing-component-type")
 


### PR DESCRIPTION
Also don't parse infos from appstreamcli validate


Some applications still have ancient metainfo https://github.com/flathub/com.discordapp.Discord/pull/373

catalogue will always start with component but can't rely on metainfo doing the same, so it's better to stop parsing entirely and return an error.