### PR TITLE
Remove console-app-no-binary from overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container:
-      image: debian:testing
     steps:
       - uses: actions/checkout@v3
 
@@ -20,13 +18,13 @@ jobs:
 
       - name: Install flatpak-builder
         run: |
-          apt-get update
-          apt-get install -y flatpak-builder jq appstream curl
+          sudo apt-get update
+          sudo apt-get install -y flatpak-builder jq appstream curl
 
       - name: Setup Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          ln -s /github/home/.local/bin/poetry /usr/bin/poetry
+          sudo ln -s /github/home/.local/bin/poetry /usr/bin/poetry
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,13 @@ jobs:
       - name: Install flatpak-builder
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak-builder jq appstream curl
+          sudo apt-get install -y flatpak flatpak-builder jq curl dbus-daemon
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.flatpak.Builder//stable
+          echo '#!/bin/sh' > /usr/local/bin/appstreamcli
+          echo "exec dbus-run-session flatpak run --filesystem=/tmp --command=appstreamcli org.flatpak.Builder \${@}" >> /usr/local/bin/appstreamcli
+          chmod +x /usr/local/bin/appstreamcli
+          appstreamcli --version
 
       - name: Setup Poetry
         run: |

--- a/flatpak_builder_lint/appstream.py
+++ b/flatpak_builder_lint/appstream.py
@@ -21,7 +21,6 @@ def validate(path: str) -> dict:
         "cid-maybe-not-rdns": "error",
         "cid-missing-affiliation-gnome": "error",
         "cid-rdns-contains-hyphen": "error",
-        "console-app-no-binary": "info",
         "content-rating-missing": "error",
         "desktop-app-launchable-omitted": "error",
         "desktop-file-not-found": "error",

--- a/tests/builddir/appdata-quality/files/share/metainfo/com.github.flathub.appdata-quality.metainfo.xml
+++ b/tests/builddir/appdata-quality/files/share/metainfo/com.github.flathub.appdata-quality.metainfo.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--This file should pass validation using appstreamcli of linter-->
 <component>
   <id>com.github.flathub.appdata-quality</id>
   <name>Example</name>
@@ -21,6 +22,6 @@
     <keyword>Foo</keyword>
   </keywords>
   <categories>
-    <category>Foo</category>
+    <category>Utility</category>
   </categories>
 </component>

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -120,3 +120,6 @@ def test_builddir_quality_guidelines() -> None:
         assert w in found_warnings
     for e in errors:
         assert e in found_errors
+    # If present, it means a metainfo file that was validating
+    # correctly broke and that should be fixed
+    assert "appstream-failed-validation" not in found_errors


### PR DESCRIPTION
It can't be reduced to Info nor can it be kept as a warning or an error to provide compat

Instead patch appstream in org.flatpak.Builder to reduce to info