### PR TITLE
Add exception for sway-input-config

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2391,5 +2391,8 @@
     "org.kde.kopete": {
         "appstream-failed-validation": "grandfathered due to unannounced linter changes",
         "appstream-missing-developer-name": "grandfathered due to unannounced linter changes"
+    },
+    "io.github.Sunderland93.sway-input-config": {
+        "finish-args-unnecessary-xdg-config-access": "Required to access Sway configuration on host"
     }
 }


### PR DESCRIPTION
Without this `sway-input-config` can't apply configs for Sway