### PR TITLE
Add finish-args-unnecessary-xdg-config-access exception for io.github.realmazharhussain.GdmSettings

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1136,6 +1136,7 @@
     },
     "io.github.realmazharhussain.GdmSettings": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+	"finish-args-unnecessary-xdg-config-access": "required for 'apply current display settings to GDM' feature",
     },
     "io.github.shiftey.Desktop": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1135,8 +1135,8 @@
         "appid-code-hosting-too-few-components": "the app predates this linter rule"
     },
     "io.github.realmazharhussain.GdmSettings": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-	"finish-args-unnecessary-xdg-config-access": "required for 'apply current display settings to GDM' feature",
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-config-access": "required for 'apply current display settings to GDM' feature"
     },
     "io.github.shiftey.Desktop": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"


### PR DESCRIPTION
Read access to $XDG_CONFIG_DIR/monitors.xml is required by GDM Settings for applying current/session display settings to GDM login manager.