### PR TITLE
exceptions: Add appinfo missing exceptions to CLI apps shipped from fsdk

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2392,5 +2392,20 @@
     },
     "io.github.Sunderland93.sway-input-config": {
         "finish-args-unnecessary-xdg-config-access": "Required to access Sway configuration on host"
+    },
+    "org.freedesktop.Platform.VulkanInfo": {
+        "appstream-missing-appinfo-file": "grandfathered due to unannounced linter changes"
+    },
+    "org.freedesktop.Platform.VdpauInfo": {
+        "appstream-missing-appinfo-file": "grandfathered due to unannounced linter changes"
+    },
+    "org.freedesktop.Platform.ClInfo": {
+        "appstream-missing-appinfo-file": "grandfathered due to unannounced linter changes"
+    },
+    "org.freedesktop.Platform.GlxInfo": {
+        "appstream-missing-appinfo-file": "grandfathered due to unannounced linter changes"
+    },
+    "org.freedesktop.Platform.VaInfo": {
+        "appstream-missing-appinfo-file": "grandfathered due to unannounced linter changes"
     }
 }

--- a/validator.py
+++ b/validator.py
@@ -52,6 +52,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "flathub-json-deprecated-i386-arch-included",
                     "toplevel-no-command",
                     "flathub-json-skip-appstream-check",
+                    "appstream-missing-appinfo-file",
                 }
                 if not found_exceptions.issubset(known_exceptions):
                     print("Exception not found in known exceptions list", found_exceptions - known_exceptions)


### PR DESCRIPTION
Due to unannounced linter changes they were not aware of a metainfo file requirement for cli app refs