### PR TITLE
Add exception for org.linuxshowplayer.LinuxShowPlayer

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2408,5 +2408,8 @@
     },
     "org.freedesktop.Platform.VaInfo": {
         "appstream-missing-appinfo-file": "grandfathered due to unannounced linter changes"
+    },
+    "org.linuxshowplayer.LinuxShowPlayer": {
+        "finish-args-flatpak-spawn-access": "Required by CommandCue(s) to allow users to interact with external tools"
     }
 }


### PR DESCRIPTION
Linux Show Player provide the option to run custom commands, this allow users to interact with external tools installed on the host system.

Documentation of the feature: https://linux-show-player-users.readthedocs.io/en/latest/cues/misc_cues.html#command-cue

User report for the broken functionality: https://github.com/FrancescoCeruti/linux-show-player/discussions/308