### PR TITLE
add exception of org.DolphinEmu.dolphin-emu

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2411,5 +2411,8 @@
     },
     "org.linuxshowplayer.LinuxShowPlayer": {
         "finish-args-flatpak-spawn-access": "Required by CommandCue(s) to allow users to interact with external tools"
+    },
+    "org.DolphinEmu.dolphin-emu": {
+        "appstream-failed-validation": "app-id predates this linter rule"
     }
 }


### PR DESCRIPTION
The id `org.DolphinEmu.dolphin-emu` fails validation because of the uppercase letters, however, I'm unable to change it.

Failed build:

https://buildbot.flathub.org/#/builders/6/builds/104677

Pull request I'm trying to merge:

https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/190