### PR TITLE
finish-args: redundant-device-all should not trigger when shm is present

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -132,7 +132,8 @@ class FinishArgsCheck(Check):
             self.warnings.add("finish-args-deprecated-shm")
 
         if "all" in finish_args["device"] and len(finish_args["device"]) > 1:
-            self.warnings.add("finish-args-redundant-device-all")
+            if "shm" not in finish_args["device"]:
+                self.warnings.add("finish-args-redundant-device-all")
 
         if "org.freedesktop.Flatpak" in finish_args["talk-name"]:
             self.errors.add("finish-args-flatpak-spawn-access")

--- a/tests/builddir/finish_args/metadata
+++ b/tests/builddir/finish_args/metadata
@@ -4,7 +4,7 @@ name=org.flathub.finish_args
 [Context]
 share=!network;
 sockets=x11;wayland;session-bus;fallback-x11;!cups;
-devices=all;shm;!dri;
+devices=all;!dri;
 filesystems=home;xdg-data;xdg-config/autostart;host;xdg-data/foo:create;/run/media/foo;
 
 [Session Bus Policy]

--- a/tests/builddir/finish_args_shm/metadata
+++ b/tests/builddir/finish_args_shm/metadata
@@ -1,0 +1,5 @@
+[Application]
+name=org.flathub.finish_args_shm
+
+[Context]
+devices=shm;

--- a/tests/manifests/finish-args-shm.json
+++ b/tests/manifests/finish-args-shm.json
@@ -1,0 +1,6 @@
+{
+    "app-id": "org.flathub.finish_args_shm",
+    "finish-args": [
+        "--device=shm"
+    ]
+}

--- a/tests/manifests/finish_args.json
+++ b/tests/manifests/finish_args.json
@@ -2,7 +2,6 @@
     "app-id": "org.flathub.finish_args",
     "finish-args": [
         "--device=all",
-        "--device=shm",
         "--nodevice=dri",
         "--filesystem=home",
         "--filesystem=host",

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -35,7 +35,6 @@ def test_builddir_finish_args() -> None:
     }
 
     warnings = {
-        "finish-args-deprecated-shm",
         "finish-args-x11-without-ipc",
         "finish-args-redundant-device-all",
     }
@@ -53,6 +52,14 @@ def test_builddir_finish_args() -> None:
     assert warnings.issubset(found_warnings)
     for a in expected_absents:
         assert a not in found_errors
+
+
+def test_manifest_finish_args_shm() -> None:
+
+    ret = run_checks("tests/builddir/finish_args_shm")
+    found_warnings = set(ret["warnings"])
+
+    assert "finish-args-deprecated-shm" in found_warnings
 
 
 def test_builddir_display_supported() -> None:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -79,7 +79,6 @@ def test_manifest_finish_args() -> None:
 
     warnings = {
         "finish-args-contains-both-x11-and-wayland",
-        "finish-args-deprecated-shm",
         "finish-args-x11-without-ipc",
         "finish-args-redundant-device-all",
         "finish-args-contains-both-x11-and-fallback",
@@ -109,6 +108,14 @@ def test_manifest_finish_args_issue_33() -> None:
     ret = run_checks("tests/manifests/own_name_substring2.json")
     found_errors = set(ret["errors"])
     assert "finish-args-unnecessary-appid-own-name" in found_errors
+
+
+def test_manifest_finish_args_shm() -> None:
+
+    ret = run_checks("tests/manifests/finish-args-shm.json")
+    found_warnings = set(ret["warnings"])
+
+    assert "finish-args-deprecated-shm" in found_warnings
 
 
 def test_manifest_display_stuff() -> None:


### PR DESCRIPTION
all does not cover shm

man flatpak-metadata
> /dev/shm (which is separately specified)

Seperate the tests to that affect too