### PR TITLE
Add flatpak-spawn exception for dev.neovide.Neovide

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2411,5 +2411,8 @@
     },
     "org.linuxshowplayer.LinuxShowPlayer": {
         "finish-args-flatpak-spawn-access": "Required by CommandCue(s) to allow users to interact with external tools"
+    },
+    "dev.neovide.Neovide": {
+        "finish-args-flatpak-spawn-access": "required to allow spawning neovim on the host"
     }
 }


### PR DESCRIPTION
This exception is needed to allow Neovide to execute the host's `nvim` binary.