### PR TITLE
exceptions.json: allow flatpak-spawn --host from gplaces

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -226,7 +226,8 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "com.github.dimkr.gplaces": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-flatpak-spawn-access": "required to handle unsupported MIME types and URLs"
     },
     "com.github.donadigo.appeditor": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"


### PR DESCRIPTION
gplaces uses user-defined programs to handle non-text MIME types (for example, the default handler for images is `chafa`) and URL schemes it doesn't support (defaults to `xdg-open`). Without working `flatpak-spawn --host`, gplaces can be annoying to use because one needs to download a file and open it using a host application, or copy the URL and paste it in the browser.