### PR TITLE
modules: Disallow git branches in modules even if commit is present

### DIFF
--- a/flatpak_builder_lint/checks/modules.py
+++ b/flatpak_builder_lint/checks/modules.py
@@ -23,12 +23,11 @@ class ModuleCheck(Check):
             tag = source.get("tag")
             branch_committish = False
 
-            if not commit:
-                if branch:
-                    if len(branch) != 40:
-                        self.errors.add(f"module-{module_name}-source-git-branch")
-                    else:
-                        branch_committish = True
+            if branch:
+                if len(branch) != 40:
+                    self.errors.add(f"module-{module_name}-source-git-branch")
+                else:
+                    branch_committish = True
 
             if not branch_committish and not commit and not tag:
                 self.errors.add(f"module-{module_name}-source-git-no-commit-or-tag")

--- a/tests/manifests/modules_git_allowed.json
+++ b/tests/manifests/modules_git_allowed.json
@@ -1,0 +1,46 @@
+{
+    "app-id": "org.flathub.modules2",
+    "modules": [
+        {
+            "name": "module1",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://foobar2.git",
+                    "commit": "1234567890abcdef1234567890abcdef12345678"
+                }
+            ]
+        },
+        {
+            "name": "module2",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://foobar2.git",
+                    "branch": "f49cf6381e322b147053b74e4500af8533ac1e4c"
+                }
+            ]
+        },
+        {
+            "name": "module3",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://foobar2.git",
+                    "tag": "1234567890abcdef1234567890abcdef12345678"
+                }
+            ]
+        },
+        {
+            "name": "module4",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://foobar2.git",
+                    "tag": "v1.0.0",
+                    "commit": "1234567890abcdef1234567890abcdef12345678"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/manifests/modules_git_disallowed.json
+++ b/tests/manifests/modules_git_disallowed.json
@@ -6,9 +6,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://foobar2.git",
-                    "branch": "master",
-                    "commit": "1234567890abcdef1234567890abcdef12345678"
+                    "url": "https://foobar2.git"
                 }
             ]
         },
@@ -17,8 +15,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://foobar2.git",
-                    "branch": "f49cf6381e322b147053b74e4500af8533ac1e4c"
+                    "path": "../"
                 }
             ]
         },
@@ -26,9 +23,7 @@
             "name": "module3",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://foobar2.git",
-                    "tag": "1234567890abcdef1234567890abcdef12345678"
+                    "type": "git"
                 }
             ]
         },
@@ -37,8 +32,18 @@
             "sources": [
                 {
                     "type": "git",
+                    "url": "ssh://foobar2.git",
+                    "commit": "8bdc272f381e2633b96d1846994c7cb0f90f079f"
+                }
+            ]
+        },
+        {
+            "name": "module5",
+            "sources": [
+                {
+                    "type": "git",
                     "url": "https://foobar2.git",
-                    "tag": "1234567890abcdef1234567890abcdef12345678"
+                    "branch": "branch_name"
                 }
             ]
         }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -193,10 +193,16 @@ def test_manifest_modules() -> None:
     assert warnings.issubset(found_warnings)
 
 
-def test_manifest_modules_git() -> None:
-    ret = run_checks("tests/manifests/modules_git.json")
+def test_manifest_modules_git_allowed() -> None:
+    ret = run_checks("tests/manifests/modules_git_allowed.json")
     found_errors = set(ret["errors"])
     assert not [x for x in found_errors if x.startswith("module-")]
+
+
+def test_manifest_modules_git_disallowed() -> None:
+    ret = run_checks("tests/manifests/modules_git_disallowed.json")
+    found_errors = set(ret["errors"])
+    assert [x for x in found_errors if x.startswith("module-")]
 
 
 def test_manifest_exceptions() -> None:


### PR DESCRIPTION
It is only allowed when the `branch` value is itself a commit hash.

Only `branch` with an actual branch name is non-reproducible, a `branch` and a `commit` means build fails whenever they mismatch.

Fix and seperate tests to that effect.

Closes https://github.com/flathub-infra/flatpak-builder-lint/issues/345