### PR TITLE
exceptions: Remove DiscordCanary as it works without permission now

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1764,9 +1764,6 @@
     "com.discordapp.Discord": {
         "finish-args-wildcard-kde-own-name": "Initial import, outdated Electron, still uses legacy StatusNotifier implementation"
     },
-    "com.discordapp.DiscordCanary": {
-        "finish-args-wildcard-kde-own-name": "Initial import, outdated Electron, still uses legacy StatusNotifier implementation"
-    },
     "com.hunterwittenborn.Celeste": {
         "finish-args-wildcard-kde-own-name": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation"
     },


### PR DESCRIPTION
See https://github.com/flathub/com.discordapp.DiscordCanary/issues/78