### PR TITLE
Add flatpak-spawn-access exception for com.core447.StreamController

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2416,5 +2416,8 @@
     },
     "dev.neovide.Neovide": {
         "finish-args-flatpak-spawn-access": "required to allow spawning neovim on the host"
+    },
+    "com.core447.StreamController": {
+        "finish-args-flatpak-spawn-access": "required to allow plugins to open apps on the host"
     }
 }


### PR DESCRIPTION
StreamController is a Linux app for the Elgato Stream Deck with plugin support.

Why do I need the `flatpak-spawn-access` permission?
Because it allows the user to system command to the keys. This can be used to launch apps, shutdown the system, copy files, etc.

Of course, StreamController itself does not execute the mentioned commands, but only if the user specifies them for his actions.