### PR TITLE
Add exception for Junction

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1326,7 +1326,8 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "re.sonny.Junction": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+        "finish-args-flatpak-spawn-access": "required to launch apps",
+        "finish-args-unnecessary-xdg-data-access": "required to list apps"
     },
     "space.crankshaft.Crankshaft": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"


### PR DESCRIPTION
Junction has always needed `xdg-data/applications` and `xdg-data/flatpak` and was using them before the linter rule was introduced.

see https://github.com/flathub/re.sonny.Junction/blob/136c2d85fd52519578f85693c257912e1126bc21/re.sonny.Junction.json#L15-L16