### PR TITLE
Add exception for Brave Browser

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2427,5 +2427,8 @@
     },
     "page.codeberg.JakobDev.jdMacroPlayer": {
         "finish-args-flatpak-spawn-access": "Run ydotoold on the Host"
+    },
+    "com.brave.Browser": {
+        "flathub-json-modified-publish-delay": "Allow setting the delay to 0 to ensure users get the latest version as soon as possible"
     }
 }


### PR DESCRIPTION
This allows us to set publish-delay-hours to 0 which should minimize the delay to ~1 hour after updating the Brave flatpak.

CC @oajara