### PR TITLE
chore: add dependabot configuration for scheduled dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Changes

Continuing #166, this PR adds a dependabot config file to schedule automatic dependency updates (with PRs by dependabot) in a monthly schedule. This would ensure the dependencies are up to date and would allow addressing any breaking changes in the dependent packages then and there.

## Detailed Explanation of changes

```md
version: 2 # this is the version type of the dependabot config file with 2 being the recent one
updates:
  - package-ecosystem: "github-actions" # checks for updates to the GitHub actions in use.
    directory: "/" # scans the full root directory for updates (optionally, we can make this fine-grained to point to .github/workflows)
    schedule:
      interval: "monthly" # scheduling dependabot updates monthly

  - package-ecosystem: "pip"  # checks for updates to the Python (Poetry) deps in use.
    directory: "/" # scans the full root directory for updates
    schedule:
      interval: "monthly" # scheduling dependabot updates monthly
```