### PR TITLE
metainfo: Check if launchable defined in appstream is actually installed

### DIFF
--- a/flatpak_builder_lint/appstream.py
+++ b/flatpak_builder_lint/appstream.py
@@ -68,6 +68,11 @@ def appstream_id(path: str) -> Optional[str]:
     return str(aps_cid)
 
 
+def get_launchable(path: str) -> list:
+    launchable = components(path)[0].xpath("launchable[@type='desktop-id']/text()")
+    return list(launchable)
+
+
 def is_developer_name_present(path: str) -> bool:
     developer_name = components(path)[0].xpath("developer/name")
     legacy_developer_name = components(path)[0].xpath("developer_name")

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -12,6 +12,7 @@ class MetainfoCheck(Check):
     def _validate(self, path: str, appid: str) -> None:
         appstream_path = f"{path}/app-info/xmls/{appid}.xml.gz"
         appinfo_icon_dir = f"{path}/app-info/icons/flatpak/128x128/"
+        launchable_dir = f"{path}/applications"
         icon_path = f"{path}/icons/hicolor"
         glob_path = f"{icon_path}/*/apps/*"
         metainfo_dirs = [
@@ -85,6 +86,16 @@ class MetainfoCheck(Check):
             "desktop",
             "desktop-application",
         ):
+
+            if not appstream.get_launchable(appstream_path):
+                self.errors.add("metainfo-missing-launchable-tag")
+
+            if appstream.get_launchable(appstream_path):
+                launchable_value = appstream.get_launchable(appstream_path)[0]
+                launchable_file_path = f"{launchable_dir}/{launchable_value}"
+                if not os.path.exists(launchable_file_path):
+                    self.errors.add("appstream-launchable-file-missing")
+
             icon_filename = appstream.get_icon_filename(appstream_path)
             appinfo_icon_path = f"{appinfo_icon_dir}/{icon_filename}"
 

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -151,6 +151,7 @@ def test_builddir_quality_guidelines() -> None:
         "appstream-missing-project-license",
         "no-exportable-icon-installed",
         "metainfo-missing-component-type",
+        "appstream-launchable-file-missing",
     }
     warnings = {
         "appstream-name-too-long",
@@ -166,7 +167,11 @@ def test_builddir_quality_guidelines() -> None:
         assert e in found_errors
     # If present, it means a metainfo file that was validating
     # correctly broke and that should be fixed
-    not_founds = {"appstream-failed-validation" "appstream-id-mismatch-flatpak-id"}
+    not_founds = {
+        "appstream-failed-validation",
+        "appstream-id-mismatch-flatpak-id",
+        "metainfo-missing-launchable-tag",
+    }
     for e in not_founds:
         assert e not in found_errors
 
@@ -205,6 +210,7 @@ def test_min_success_metadata() -> None:
     # CLI applications are allowed to have no finish-args with exceptions
     accepted = {"finish-args-not-defined"}
     assert len(found_errors - accepted) == 0
+    assert "metainfo-missing-launchable-tag" not in found_errors
 
 
 def test_builddir_aps_cid_mismatch_flatpak_id() -> None:


### PR DESCRIPTION
For legacy ids that end in `.desktop`, appstreamcli validate does not raise the usual launchable missing error here and assumes the file is present. compose also ignores that the file does not exist