### PR TITLE
Randovania: added xdg-config allowance

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1177,6 +1177,9 @@
     "io.github.prateekmedia.appimagepool": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "io.github.randovania.Randovania": {
+        "finish-args-unnecessary-xdg-config-access": "required to export a randomizer to the host's Ryujinx settings"
+    },
     "io.github.Qalculate": {
         "appid-code-hosting-too-few-components": "the app predates this linter rule"
     },


### PR DESCRIPTION
It's wished for the Flatpak version of Randovania to export a Dread randomizer to the host's Ryujinx settings located at the host's $XDG_CONFIG/Ryujinx

Relevant PR for manifest: https://github.com/flathub/io.github.randovania.Randovania/pull/20

