### PR TITLE
exceptions: Add RPCS3 to branch exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3203,5 +3203,8 @@
     },
     "org.goldendict.GoldenDict": {
         "module-goldendict-source-git-branch": "Needed for x-checker as upstream does not tag releaases."
+    },
+    "net.rpcs3.RPCS3": {
+        "module-rpcs3-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation."
     }
 }


### PR DESCRIPTION
They use a custom updater via Github Workflow to update once per day as upstream creates builds on each commit.

> Please note that our version increases are landmarks and not stable builds
> Always download the latest build from

https://rpcs3.net/download

See https://github.com/flathub/net.rpcs3.RPCS3/issues/1679