### PR TITLE
Add io.gitlab.liferooter.TextPieces to exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1196,6 +1196,9 @@
     "io.gitlab.librewolf-community": {
         "appid-code-hosting-too-few-components": "the app predates this linter rule"
     },
+    "io.gitlab.liferooter.textpieces": {
+        "finish-args-flatpak-spawn-access": "required for running user-defined text actions in host environment"
+    },
     "io.howl.Editor": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },


### PR DESCRIPTION
I'm the developer of [Text Pieces](https://apps.gnome.org/Textpieces). I've just finished rewritting it. During the rewrite, it was moved from GitHub to GitLab with corresponding ID change. So now it's not `com.github.liferooter.textpieces`, but `io.gitlab.liferooter.TextPieces`. So I need to add it to the list of exceptions, because it still needs `--talk-name=org.freedesktop.Flatpak` permission.