### PR TITLE
Fix case of io.gitlab.liferooter.TextPieces

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1197,7 +1197,7 @@
     "io.gitlab.librewolf-community": {
         "appid-code-hosting-too-few-components": "the app predates this linter rule"
     },
-    "io.gitlab.liferooter.textpieces": {
+    "io.gitlab.liferooter.TextPieces": {
         "finish-args-flatpak-spawn-access": "required for running user-defined text actions in host environment"
     },
     "io.howl.Editor": {


### PR DESCRIPTION
I've just made a [PR](#387) that adds `io.gitlab.liferooter.TextPieces` to the exception list, but I've accidentally wrote `textpieces` in lower-case instead of mixed-case `TextPieces`. This commit fixes it.