### PR TITLE
Add io.github.elevenhsoft.WebApps to exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3227,5 +3227,8 @@
     },
     "net.rpcs3.RPCS3": {
         "module-rpcs3-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation."
+    },
+    "io.github.elevenhsoft.WebApps": {
+        "finish-args-unnecessary-xdg-data-access": "WebApps need rw permission for xdg-data to be able to create new profiles for web browsers to isolate them as well as create new desktop files."
     }
 }


### PR DESCRIPTION
Hey,
I'm developing COSMIC Web Apps. It's allow to create "web applications" from your web browser of choice.
Unfortunately it's need `rw` permissions for creating desktop files and `ro` for reading what web browsers user have installed.