### PR TITLE
Add xdg-config exception for page.codeberg.libre_menu_editor.LibreMenuEditor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8,7 +8,8 @@
         "*": "ignore all errors and warnings"
     },
     "page.codeberg.libre_menu_editor.LibreMenuEditor": {
-        "finish-args-unnecessary-xdg-data-access": "this program needs write-access to xdg-data/applications and read-access to xdg-data/flatpak"
+        "finish-args-unnecessary-xdg-data-access": "this program needs write-access to xdg-data/applications and read-access to xdg-data/flatpak",
+        "finish-args-unnecessary-xdg-config-access": "this program needs write-access to xdg-config/mimeapps.list"
     },
     "com.github.sixpounder.GameOfLife": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"


### PR DESCRIPTION
This program is a Menu Editor. The latest version requires write access to xdg-config/mimeapps.list in order to fix a bug.