### PR TITLE
finish_args: /bin is also a reserved path

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -63,6 +63,7 @@ class FinishArgsCheck(Check):
             for resv_dir in [
                 ".flatpak-info",
                 "app",
+                "bin",
                 "dev",
                 "etc",
                 "lib",


### PR DESCRIPTION
It is missing from the blocklist