### PR TITLE
exceptions: update app-id for Ptyxis

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -944,7 +944,7 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
-    "org.gnome.Ptyxis": {
+    "app.devsuite.Ptyxis": {
         "finish-args-flatpak-spawn-access": "application requires ptyxis-agent for PTY setup on host"
     },
     "org.gnome.Totem.Devel": {


### PR DESCRIPTION
Ptyxis is required to use an alternate app-id when distributing on flathub and this reflects that.