### PR TITLE
Add exceptions for io.github.loot.loot

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3229,5 +3229,9 @@
     },
     "net.rpcs3.RPCS3": {
         "module-rpcs3-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation."
+    },
+    "io.github.loot.loot": {
+	"finish-args-unnecessary-xdg-config-access": "Needed to detect games installed through Heroic Games Launcher.",
+        "finish-args-unnecessary-xdg-data-access": "Needed to detect and make changes to games installed through Steam."
     }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3231,7 +3231,7 @@
         "module-rpcs3-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation."
     },
     "io.github.loot.loot": {
-	"finish-args-unnecessary-xdg-config-access": "Needed to detect games installed through Heroic Games Launcher.",
+        "finish-args-unnecessary-xdg-config-access": "Needed to detect games installed through Heroic Games Launcher.",
         "finish-args-unnecessary-xdg-data-access": "Needed to detect and make changes to games installed through Steam."
     }
 }


### PR DESCRIPTION
Read access to Steam and Heroic config are necessary to support autodetection of installed games. Read and write access to Steam and Heroic game installs is required for core functionality (though Heroic's default game install path is outside xdg-config/xdg-data, so isn't affected by these linter rules).

The UX would be much worse if it didn't just work out of the box and users had to manually grant access or configure their game paths.