### PR TITLE
Add exception for io.github.pantheon_tweaks.pantheon-tweaks

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3233,5 +3233,8 @@
     "io.github.loot.loot": {
         "finish-args-unnecessary-xdg-config-access": "Needed to detect games installed through Heroic Games Launcher.",
         "finish-args-unnecessary-xdg-data-access": "Needed to detect and make changes to games installed through Steam."
+    },
+    "io.github.pantheon_tweaks.pantheon-tweaks": {
+        "finish-args-flatpak-spawn-access": "Needed to get XDG_DATA_DIRS with flatpak-swapn to bridge host's GSettings."
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/flathub/flathub/pull/5266#discussion_r1606015669

This app needs to get ability to read/write host's GSettings, but there is no way to do that in Flatpak or Poral. So, the app gets the host's XDG_DATA_DIRS environment value with flatpak-spawn and bridges `schemas` directories under each directory in that value.