### PR TITLE
 exceptions: Add Subsurface to branch exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3182,6 +3182,9 @@
     "org.sparkleshare.SparkleShare": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
+    "org.subsurface_divelog.Subsurface": {
+        "module-subsurface-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation."
+    },
     "org.tabos.maxcontrol": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },


### PR DESCRIPTION
They use a custom updater via Github Workflow to update once per day as upstream creates builds on each commit.

> After a few years of doing release builds not on GitHub, we have come full circle, but in a different way.
> We now do "nightly" builds (they actually happen when our main branch changes) and post them in a separate nightly build repo

Cf. 

https://github.com/subsurface/subsurface/releases/tag/v4.9.4

and

https://subsurface-divelog.org/current-release/?lang=en

Also, unit tests are run after every Flathub build and prevent merging an update if they fail:

https://github.com/flathub/org.subsurface_divelog.Subsurface/blob/master/org.subsurface_divelog.Subsurface.yaml#L226

Regarding buildbot usage: The build only takes 10 min and I can just set the Actions workflow to be triggered once a week

![image](https://github.com/flathub-infra/flatpak-builder-lint/assets/3226457/121583de-0aee-44b0-9a5f-49394f4ee342)
