### PR TITLE
exceptions: add flatpak-spawn for app.devsuite.Manuals

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -949,6 +949,9 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
+    "app.devsuite.Manuals": {
+        "finish-args-flatpak-spawn-access": "application uses libflatpak to install SDK documentation"
+    },
     "app.devsuite.Ptyxis": {
         "finish-args-flatpak-spawn-access": "application requires ptyxis-agent for PTY setup on host"
     },


### PR DESCRIPTION
Manuals uses libflatpak to install SDK documentation on either the --user or --system Flatpak installation.

For https://github.com/flathub/flathub/pull/5299