### PR TITLE
exceptions: allow automerge for com.fightcade.Fightcade

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1466,7 +1466,8 @@
         "flathub-json-modified-publish-delay": "extra-data"
     },
     "com.fightcade.Fightcade": {
-        "flathub-json-modified-publish-delay": "Client version must be in sync with server to function"
+        "flathub-json-modified-publish-delay": "Client version must be in sync with server to function",
+        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function"
     },
     "com.flashforge.FlashPrint": {
         "flathub-json-modified-publish-delay": "extra-data"


### PR DESCRIPTION
The Fightcade client needs to be in sync with the current server version to function. If an update causes breakages the end result is identical to having an outdated Flatpak (the client will not work in either case.)

Allow Flathubbot automerging to keep the client in sync even when a developer with merge access is unavailable.