### PR TITLE
Exclude org.gnome.Calls from automerge

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3146,5 +3146,8 @@
     },
     "xyz.armcord.ArmCord": {
         "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "org.gnome.Calls": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
     }
 }


### PR DESCRIPTION
This has been in place since [over two years](https://github.com/flathub/org.gnome.Calls/commit/613ce32b359a03685cbfcecbb1f23315c7825838).

Without the auto-merge feature, the maintenance effort will be too high for me and I will step down as maintainer of this package.