### PR TITLE
exceptions: allow automerge for com.discordapp.DiscordCanary

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1858,6 +1858,9 @@
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "flathub-json-automerge-enabled": "Predates the linter rule"
     },
+    "com.discordapp.DiscordCanary": {
+        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients are forced to update"
+    },
     "com.hunterwittenborn.Celeste": {
         "finish-args-wildcard-kde-own-name": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation"
     },


### PR DESCRIPTION
Discord client requires all clients to be up-to-date:

![screenshot](https://github.com/flathub-infra/flatpak-builder-lint/assets/19509291/d4ea7569-23a1-40b9-852f-cd6299a2dbc1)

TBH, this can be workarounded by [disabling internal update checker](https://github.com/flathub/com.discordapp.DiscordCanary/blob/beta/disable-breaking-updates.py), but all clients still should be updated ASAP as outdated client may block users from using Discord or break some features. Automerging allows users to be in-sync with Discord updates and worked fine for years. In addition, `com.discordapp.Discord` is currently using automerge as well.

*PS Automerge was disabled in https://github.com/flathub/com.discordapp.DiscordCanary/commit/bec771e41d0810682f716222f3c9a5f0edfa14f9 to allow manual updates, but I would like it to be restored*