### PR TITLE
exceptions: allow xdg-data access to net.codelogistics.webapps

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1217,6 +1217,9 @@
     "io.stoplight.studio": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "net.codelogistics.webapps": {
+        "finish-args-arbitrary-xdg-data-access": "The app creates and removes desktop files in ~/.local/share/applications."
+    },
     "net.cozic.joplin_desktop": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },


### PR DESCRIPTION
Web Apps installs websites as desktop applications, using xdg-desktop-portal's dynamic launcher portal for the same until now. However, I received multiple bug reports and complaints that the app was not working on various desktop environments and distros due to incomplete or outdated implementations of the portal and so the app now creates and removes desktop files in ~/.local/share/applications directly.