### PR TITLE
Update exceptions.json

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1621,6 +1621,9 @@
     "io.github.MakovWait.Godots": {
         "finish-args-flatpak-spawn-access": "flatpak-spawn is needed for blender and external code editors"
     },
+    "com.github.yairm210.unciv": {
+        "flathub-json-automerge-enabled": "Semiweekly release"
+    },
     "io.wavebox.Wavebox": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
Added automerge exception for Unciv - averages to 2 releases a week

Unciv itself is build in a Github Actions pipeline - if you would rather I use the [Github action](https://github.com/flathub-infra/flatpak-github-actions) for flatpak releases I could do that, not sure if there are problems in "transferring" from the bot to the github action