### PR TITLE
exceptions: add dev.lizardbyte.dev.Sunshine

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1133,6 +1133,9 @@
     "dev.lapce.lapce": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "dev.lizardbyte.app.Sunshine": {
+        "finish-args-flatpak-spawn-access": "needed to start applications"
+    },
     "dev.salaniLeo.immagini": {
         "finish-args-flatpak-spawn-access": "needed to start applications"
     },


### PR DESCRIPTION
Sunshine requires the ability to start applications.

See: https://github.com/flathub/dev.lizardbyte.app.Sunshine/issues/36#issuecomment-2203990470