### PR TITLE
Add exception for dev.edfloreshz.Tasks

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3816,5 +3816,8 @@
     },
     "dev.bsnes.bsnes": {
         "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "needs access to xdg-config/gtk-3.0 for theming, does not support portals"
+    },
+    "dev.edfloreshz.Tasks": {
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
     }
 }


### PR DESCRIPTION
COSMIC applications require read-only access to the host in order to watch for changes in the system theme and sync with it.

Can we add an exception?