### PR TITLE
Add exception for dev.mariinkys.Oboete

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3819,5 +3819,8 @@
     },
     "dev.edfloreshz.Tasks": {
         "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+    },
+    "dev.mariinkys.Oboete": {
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
     }
 }


### PR DESCRIPTION
As stated on: https://github.com/flathub-infra/flatpak-builder-lint/pull/430

COSMIC applications require read-only access to the host in order to watch for changes in the system theme and sync with it.

Hopefully an exception can be added. 