### PR TITLE
Add exceptions for "finish-args-contains-both-x11-and-wayland" for org.godotengine.Godot and org.godotengine.GodotSharp

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1363,7 +1363,8 @@
         "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
     },
     "org.godotengine.GodotSharp": {
-        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
+        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Godot will fail to start up in Wayland sessions as X11 is still the default."
     },
     "org.jabref.jabref": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1353,7 +1353,8 @@
     },
     "org.godotengine.Godot": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Godot will fail to start up in Wayland sessions as X11 is still the default. The change this error arises from, https://github.com/flathub/org.godotengine.Godot/pull/170, predates this linter rule."
     },
     "org.godotengine.Godot3": {
         "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"


### PR DESCRIPTION
Currently, the `beta` branch for `org.godotengine.Godot` (Godot **4**, that is) has access to both the [X11](https://github.com/flathub/org.godotengine.Godot/blob/cd364fb20d5bdef9c5e9aebb14c59b7fa5d9405a/org.godotengine.Godot.yaml#L43) and [Wayland](https://github.com/flathub/org.godotengine.Godot/blob/cd364fb20d5bdef9c5e9aebb14c59b7fa5d9405a/org.godotengine.Godot.yaml#L42) sockets, as denoted in `finish-args`. This was introduced in https://github.com/flathub/org.godotengine.Godot/commit/673564087d94ab47611628d731cf55f617b6406d from @wjt's now merged PR https://github.com/flathub/org.godotengine.Godot/pull/170 (sorry for the ping). Usually, we would use `--socket=fallback=x11`, but in this case, without direct access to both sockets, Godot will not open on Wayland sessions, as X11 is still very much the default.

I expect the changes added to the beta branch from https://github.com/flathub/org.godotengine.Godot/pull/170 to be added to both the stable Godot Flatpak **and** the stable GodotSharp Flatpak (which, as of _this_ moment, doesn't yet have a `beta` branch) when Godot 4.3 gets a stable release, hence why I preliminarily added the exception to `org.godotengine.GodotSharp` as well as `org.godotengine.Godot`.

Once this PR is merged, I'll be able to rebuild the test build in https://github.com/flathub/org.godotengine.Godot/pull/175, which should _hopefully_ succeed without any further issues.