### PR TITLE
Add exception for dev.mariinkys.StarryDex

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3824,5 +3824,8 @@
     },
     "dev.mariinkys.Oboete": {
         "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+    },
+    "dev.mariinkys.StarryDex": {
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
     }
 }


### PR DESCRIPTION
COSMIC applications require read-only access to the host in order to watch for changes in the system theme and sync with it.