### PR TITLE
Update exceptions.json with Toolbox Tuner

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3141,6 +3141,9 @@
     "io.github.ryanabx.flatrun": {
         "finish-args-flatpak-spawn-access": "Required to install runtimes and launch flatpak bundles with the system's flatpak binary."
     },
+    "org.kuchelmeister.ToolboxTuner": {
+        "finish-args-flatpak-spawn-access": "Requires access to toolbox and podman on the host"
+    },
     "ch.tlaun.TL": {
         "flathub-json-automerge-enabled": "Predates the linter rule"
     },


### PR DESCRIPTION
The application Toolbox Tuner needs access to the host.

See discussion here:
https://github.com/flathub/flathub/pull/5400#discussion_r1672749647