### PR TITLE
appid: Use summary file to determine if app is on Flathub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder curl dbus-daemon libgirepository1.0-dev
+          sudo apt-get install -y flatpak flatpak-builder curl dbus-daemon libgirepository1.0-dev gir1.2-ostree-1.0
 
       - name: Setup Poetry
         run: |
@@ -56,12 +56,16 @@ jobs:
         run: |
           git config --global protocol.file.allow always
 
+      - name: Set up flathub remote
+        run: |
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+
       - name: Build and test org.flatpak.Builder
         run: |
           git clone --depth=1 --branch master --recursive --single-branch https://github.com/flathub/org.flatpak.Builder.git build/org.flatpak.Builder
           cd build && python3 ../docker/rewrite-manifest.py && cd org.flatpak.Builder
           rm -v flatpak-builder-lint-deps.json && cp -v ../../docker/flatpak-builder-lint-deps.json .
-          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           flatpak-builder --verbose --user --force-clean --repo=repo \
             --install-deps-from=flathub --default-branch=localtest --ccache \
             --install builddir org.flatpak.Builder.json

--- a/flatpak_builder_lint/checks/appid.py
+++ b/flatpak_builder_lint/checks/appid.py
@@ -58,7 +58,7 @@ class AppIDCheck(Check):
                 return
             if split[-1] == "Devel":
                 return
-            if domainutils.is_app_on_flathub(appid):
+            if domainutils.is_appid_on_flathub(appid):
                 return
             if appid.startswith(domainutils.code_hosts):
                 if domainutils.get_proj_url(appid) is None:

--- a/flatpak_builder_lint/domainutils.py
+++ b/flatpak_builder_lint/domainutils.py
@@ -1,4 +1,5 @@
 import os
+from functools import cache
 
 import gi
 import requests
@@ -31,6 +32,7 @@ def ignore_ref(ref: str) -> bool:
     return False
 
 
+@cache
 def get_appid(remote: str) -> set:
 
     flatpak_user_path = os.path.join(GLib.get_user_data_dir(), "flatpak", "repo")
@@ -199,6 +201,7 @@ def is_app_on_flathub(appid: str) -> bool:
     return check_url(f"https://flathub.org/api/v2/summary/{appid}", strict=True)
 
 
+@cache
 def is_appid_on_flathub(appid: str) -> bool:
 
     all_appids = get_appid("flathub") | get_appid("flathub-beta")


### PR DESCRIPTION
The API is prone to downtimes, when that happens existing apps starts to fail the check because `/summary` is down.

The only limitation is summary file is x86_64 only, so we won't get aarch64 exclusive refs.