### PR TITLE
exceptions: ca.desrt.dconf-editor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1068,7 +1068,8 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "cid-rdns-contains-hyphen": "Predates the linter rule"
     },
     "cc.nift.nsm": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"


### PR DESCRIPTION
cid-rdns-contains-hyphen: Predates the linter rule

Source: https://github.com/flathub/ca.desrt.dconf-editor/pull/30#issuecomment-2255960381