### PR TITLE
exceptions: ca.desrt.dconf-editor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1068,7 +1068,8 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "cid-missing-affiliation-gnome": "Predates the linter rule"
     },
     "cc.nift.nsm": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"


### PR DESCRIPTION
cid-missing-affiliation-gnome: Predates the linter rule

```
    "appstream": [
        "E: ca.desrt.dconf-editor.desktop:4: cid-missing-affiliation-gnome ca.desrt.dconf-editor.desktop"
    ],
```