### PR TITLE
screenshots: Add a separate error for missing screenshots in metainfo

### DIFF
--- a/flatpak_builder_lint/appstream.py
+++ b/flatpak_builder_lint/appstream.py
@@ -63,6 +63,11 @@ def components(path: str) -> list:
     return list(components)
 
 
+def metainfo_components(path: str) -> list:
+    components = parse_xml(path).xpath("/component")
+    return list(components)
+
+
 def appstream_id(path: str) -> Optional[str]:
     aps_cid = components(path)[0].xpath("id/text()")[0]
     return str(aps_cid)
@@ -87,6 +92,11 @@ def is_developer_name_present(path: str) -> bool:
 def is_project_license_present(path: str) -> bool:
     plicense = components(path)[0].xpath("project_license")
     return bool(plicense)
+
+
+def metainfo_is_screenshot_image_present(path: str) -> bool:
+    img = metainfo_components(path)[0].xpath("screenshots/screenshot/image/text()")
+    return bool(img)
 
 
 def component_type(path: str) -> str:

--- a/flatpak_builder_lint/checks/screenshots.py
+++ b/flatpak_builder_lint/checks/screenshots.py
@@ -39,6 +39,32 @@ class ScreenshotsCheck(Check):
             ):
                 return
 
+            metainfo_dirs = [f"{tmpdir}/metainfo", f"{tmpdir}/appdata"]
+            metainfo_exts = [".appdata.xml", ".metainfo.xml"]
+
+            metainfo_path = None
+            for metainfo_dir in metainfo_dirs:
+                for ext in metainfo_exts:
+                    metainfo_dirext = f"{metainfo_dir}/{appid}{ext}"
+                    if os.path.exists(metainfo_dirext):
+                        metainfo_path = metainfo_dirext
+
+            if metainfo_path is None:
+                self.errors.add("appstream-metainfo-missing")
+                self.info.add(
+                    f"appstream-metainfo-missing: No metainfo file for {appid} was found in"
+                    + " /app/share/metainfo or /app/share/appdata"
+                )
+                return
+
+            if not appstream.metainfo_is_screenshot_image_present(metainfo_path):
+                self.errors.add("metainfo-missing-screenshots")
+                self.info.add(
+                    "metainfo-missing-screenshots: The metainfo file is missing screenshots"
+                    + " or it is not present under the screenshots/screenshot/image tag"
+                )
+                return
+
             sc_allowed_urls = (
                 "https://dl.flathub.org/repo/screenshots",
                 "https://dl.flathub.org/media",
@@ -58,8 +84,7 @@ class ScreenshotsCheck(Check):
                 self.errors.add("appstream-missing-screenshots")
                 self.info.add(
                     "appstream-missing-screenshots: Catalogue file has no screenshots."
-                    + " Please check if screenshot URLs are reachable and the Metainfo file"
-                    + " has no validation errors related to screenshots"
+                    + " Please check if screenshot URLs are reachable"
                 )
                 return
 


### PR DESCRIPTION
Otherwise it reaches directly to missing screenshot tags in catalogue file - which can happen due to multiple reasons like the URLs being 404 improperly formatted etc.

So add an error to fail before reaching that. This checks if a `screenshots/screenshot/image` tag is present and non empty. Affects only desktop applications.