### PR TITLE
Port to ostree API and drop CLI usage

### DIFF
--- a/flatpak_builder_lint/checks/flathub_json.py
+++ b/flatpak_builder_lint/checks/flathub_json.py
@@ -108,13 +108,12 @@ class FlathubJsonCheck(Check):
         if not ref:
             return
 
-        flathub_json = ostree.get_flathub_json(path, ref)
-        if not flathub_json:
-            return
-
         with tempfile.TemporaryDirectory() as tmpdir:
             ostree.extract_subpath(path, ref, "/metadata", tmpdir)
             metadata = builddir.parse_metadata(tmpdir)
             if not metadata:
+                return
+            flathub_json = ostree.get_flathub_json(path, ref, tmpdir)
+            if not flathub_json:
                 return
             self._check_metadata(metadata, flathub_json)


### PR DESCRIPTION
TODO:

- [x] Restore checking if screenshot files are in the ref. Not sure if this is useful because it was just a warning since now.
- [x] Resolve these warnings:

```
** (process:116475): WARNING **: 19:59:01.778: expected enumeration type void, but got PyOSTreeRepoCheckoutMode instead

** (process:116475): WARNING **: 19:59:01.778: expected enumeration type void, but got PyOSTreeRepoCheckoutOverwriteMode instead
```