### PR TITLE
Add xdg-config-GIMP-create-access exception for GIMP.

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1004,7 +1004,8 @@
     },
     "org.gimp.GIMP": {
         "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "gtk-3.0 and GIMP config.",
-        "finish-args-unnecessary-xdg-config-GIMP-rw-access": "gtk-3.0 and GIMP config."
+        "finish-args-unnecessary-xdg-config-GIMP-rw-access": "gtk-3.0 and GIMP config.",
+        "finish-args-unnecessary-xdg-config-GIMP-create-access": "GIMP config always used"
     },
     "org.fcitx.Fcitx5": {
         "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",


### PR DESCRIPTION
GIMP is an advanced software, and people using it for years usually have dozens of resources (brushes, dynamics, patterns…) as well as plug-ins. The GUI itself is highly customizable (which tools to show, in which order, which dockables, with which size and position, etc.), so when people set up their GIMP to show a certain way, they don't want to redo it all. Not to mention the hundreds of customizable shortcuts. And more.

Furthermore we have dedicated migration code which does the right thing at each version bump, so people never lose their data from one version to another. And our config folder is fully versioned ($XDG_CONFIG_HOME/GIMP/$VERSION), so that you are able to share a same config with 2 instances of GIMP (e.g. distrib package and flatpak), without any problem. You won't get any config syntax change clash.

So anyway this was the reason why we already had the xdg-config/GIMP access exception, but this makes an inconsistency: it only use the $XDG_CONFIG_HOME folder if it already existed. This inconsistency caused problems. The "xdg-config/GIMP:create" is in fact what we need to be always consistent.

I would appreciate if this updated exception could be merged. Thanks a lot!