### PR TITLE
Add exception for io.github.lime3ds.Lime3DS

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2685,6 +2685,9 @@
     "io.github.limads.Queries": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
+    "io.github.lime3ds.Lime3DS": {
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Lime3DS creates .desktop files in .local/share/applications"
+    },
     "io.github.lxndr.gswatcher": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },


### PR DESCRIPTION
This application requires an exception for the `finish-args-unnecessary-xdg-data-applications-create-access` error as it has functionality that allows for creating game-specific shortcuts which appear in the host application menu, which involves writing to `$HOME/.local/share/applications`.