### PR TITLE
Add appid-uses-code-hosting-domain exception for com.github.corna.Vivado

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -207,6 +207,9 @@
     "com.github.christianrauch.Jahresarbeit-2003": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
+    "com.github.corna.Vivado": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
     "com.github.coslyk.MoonPlayer": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
The [com.github.corna.Vivado](https://github.com/flathub/com.github.corna.Vivado) project was created in 2021, before the above linter rule.