### PR TITLE
metainfo: Enable misplaced png or svg icon checks for console apps too

### DIFF
--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -117,39 +117,38 @@ class MetainfoCheck(Check):
                 + " captions in the Metainfo file"
             )
 
+        svg_icon_list = []
+        wrong_svgs = []
+        if os.path.exists(svg_icon_path):
+            svg_icon_list = [
+                file
+                for file in glob.glob(svg_glob_path)
+                if re.match(rf"^{appid}([-.].*)?$", os.path.basename(file))
+                and os.path.isfile(file)
+            ]
+            wrong_svgs = [i for i in svg_icon_list if not i.endswith((".svg", ".svgz"))]
+        if not all(i.endswith((".svg", ".svgz")) for i in svg_icon_list):
+            self.errors.add("non-svg-icon-in-scalable-folder")
+            self.info.add(f"non-svg-icon-in-scalable-folder: {wrong_svgs}")
+
+        png_icon_list = []
+        wrong_pngs = []
+        if os.path.exists(icon_path):
+            png_icon_list = [
+                file
+                for file in glob.glob(png_glob_path)
+                if re.match(rf"^{appid}([-.].*)?$", os.path.basename(file))
+                and os.path.isfile(file)
+            ]
+            wrong_pngs = [i for i in png_icon_list if not i.endswith(".png")]
+        if not all(i.endswith(".png") for i in png_icon_list):
+            self.errors.add("non-png-icon-in-hicolor-size-folder")
+            self.info.add(f"non-png-icon-in-hicolor-size-folder: {wrong_pngs}")
+
         if appstream.component_type(appstream_path) in (
             "desktop",
             "desktop-application",
         ):
-            svg_icon_list = []
-            wrong_svgs = []
-            if os.path.exists(svg_icon_path):
-                svg_icon_list = [
-                    file
-                    for file in glob.glob(svg_glob_path)
-                    if re.match(rf"^{appid}([-.].*)?$", os.path.basename(file))
-                    and os.path.isfile(file)
-                ]
-                wrong_svgs = [
-                    i for i in svg_icon_list if not i.endswith((".svg", ".svgz"))
-                ]
-            if not all(i.endswith((".svg", ".svgz")) for i in svg_icon_list):
-                self.errors.add("non-svg-icon-in-scalable-folder")
-                self.info.add(f"non-svg-icon-in-scalable-folder: {wrong_svgs}")
-
-            png_icon_list = []
-            wrong_pngs = []
-            if os.path.exists(icon_path):
-                png_icon_list = [
-                    file
-                    for file in glob.glob(png_glob_path)
-                    if re.match(rf"^{appid}([-.].*)?$", os.path.basename(file))
-                    and os.path.isfile(file)
-                ]
-                wrong_pngs = [i for i in png_icon_list if not i.endswith(".png")]
-            if not all(i.endswith(".png") for i in png_icon_list):
-                self.errors.add("non-png-icon-in-hicolor-size-folder")
-                self.info.add(f"non-png-icon-in-hicolor-size-folder: {wrong_pngs}")
             icon_list = svg_icon_list + png_icon_list
             if not len(icon_list) > 0:
                 self.errors.add("no-exportable-icon-installed")


### PR DESCRIPTION
Nothing is checked if the icon paths don't exist. So this still allows console apps to have no icon