### PR TITLE
exceptions: add com.vysp3r.ProtonPlus

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3922,5 +3922,8 @@
     },
     "surf.deckr.deckr": {
         "appid-url-not-reachable": "Request is returning 403, https://github.com/flathub/flathub/pull/5529#issuecomment-2325455509"
+    },
+    "com.vysp3r.ProtonPlus": {
+        "finish-args-flatpak-spawn-access": "required to install and manage compatibility-runtimes on the host"
     }
 }


### PR DESCRIPTION
Hi, I am the co-maintainer of ProtonPlus, and we have spent a few weeks working on a major update to ProtonPlus which adds support for the popular Steam Tinker Launch compatibility tool.

Due to the way STL has to be installed on the host, we need to check for dependencies via `flatpak-spawn --host which <dependency>`, and we also need to trigger STL's `steamtinkerlaunch compat add` command on the host, and another command which STL _requires_ for downloading its dependencies on Steam Deck:

https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Compatibility-Tool#command-line-usage

https://github.com/sonic2kk/steamtinkerlaunch/wiki/Installation#install

As much as it pained us to add the `flatpak-spawn` permission, there is no way around it. ProtonPlus is an application for installing, upgrading and managing compatibility tools for apps and games on Linux, and as such we unfortunately need the permission to manage those tools on the host. There is no way around it.

I hope you can help us out with this and get the next version of ProtonPlus into the hands of the users. We think they will love it as much as we do. It's been [a lot of hard work](https://github.com/Vysp3r/ProtonPlus/pull/217)! :)

Related pull request for the app update: https://github.com/flathub/com.vysp3r.ProtonPlus/pull/33

---

For reference, ProtonUp-Qt is another compatibility tool manager for Linux, which has the same permission on Flathub due to the same requirement of managing the host's runtimes:

https://github.com/flathub/net.davidotek.pupgui2