### PR TITLE
Revert "Added exception for Audio plugins BaseExtension"

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3922,8 +3922,7 @@
     "org.freedesktop.LinuxAudio.BaseExtension": {
         "finish-args-not-defined": "This provides an extension point only",
         "toplevel-no-command": "This provides an extension point only",
-        "appstream-metainfo-missing": "This provides an extension point only",
-        "flathub-json-skip-appstream-check": "This provides an extension point only"
+        "appstream-metainfo-missing": "This provides an extension point only"
     },
     "surf.deckr.deckr": {
         "appid-url-not-reachable": "Request is returning 403, https://github.com/flathub/flathub/pull/5529#issuecomment-2325455509"

--- a/utils/validator.py
+++ b/utils/validator.py
@@ -17,7 +17,6 @@ known_exceptions = {
     "finish-args-not-defined",
     "finish-args-wildcard-kde-own-name",
     "flathub-json-modified-publish-delay",
-    "flathub-json-skip-appstream-check",
     "finish-args-wildcard-kde-talk-name",
     "flathub-json-automerge-enabled",
     "appid-too-many-components-for-app",


### PR DESCRIPTION
It doesn't work, target package removed what trigger the error as it is no longer relevant.

This reverts commit cf4f375e9c9332ccd8874ee64a2725c882eae884.