### PR TITLE
Request to add "finish-args-flatpak-spawn-access" exception to "io.github.mhogomchungu.sirikali"

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "io.github.mhogomchungu.sirikali": {
+        "finish-args-flatpak-spawn-access": "this app is a front end to gocryptfs,securefs and cryfs. These tools do folder based encryption and they depend on fusermount located at /bin to mount and unmount their file systems"
+    },
     "org.flathub.exceptions": {
         "appid-filename-mismatch": "required as I like pies",
         "toplevel-no-command": "another nonsensical reason",


### PR DESCRIPTION

[io.github.mhogomchungu.sirikali](https://github.com/mhogomchungu/sirikali) is Qt/C++ front end to [secure](https://github.com/netheril96/securefs), [cryfs](https://github.com/cryfs/cryfs) and [gocryptfs](https://github.com/rfjakob/gocryptfs).

These tools depend on fusermount tool and they expect it to be located at traditional system paths(/bin or /usr/bin).

For the above reason, this app requests "finish-args-flatpak-spawn-access" exception so that it can allow these tools to access system installed fusermount through SiriKali's usage of flatpack-spawn when calling them.
