### PR TITLE
fix: permissions for com.jwestall.Forecast

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3824,7 +3824,7 @@
         "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write to system configuration files"
     },
     "com.jwestall.Forecast": {
-        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read the system theme and listen for config changes in the host"
     },
     "dev.edfloreshz.Calculator": {
         "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"


### PR DESCRIPTION
Changed from ro to rw to fix bug with cosmic application not saving config properly