### PR TITLE
Checkout only directories needed by linter

### DIFF
--- a/flatpak_builder_lint/checks/desktop.py
+++ b/flatpak_builder_lint/checks/desktop.py
@@ -254,5 +254,15 @@ class DesktopfileCheck(Check):
                 return
             if metadata.get("type", False) != "application":
                 return
-            ostree.extract_subpath(path, ref, "files/share", tmpdir)
+
+            dirs_needed = ("app-info", "applications", "icons")
+
+            for subdir in dirs_needed:
+                os.makedirs(os.path.join(tmpdir, subdir), exist_ok=True)
+
+            for subdir in dirs_needed:
+                ostree.extract_subpath(
+                    path, ref, f"files/share/{subdir}", os.path.join(tmpdir, subdir), True
+                )
+
             self._validate(tmpdir, appid)

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -248,5 +248,15 @@ class MetainfoCheck(Check):
                 return
             if metadata.get("type", False) != "application":
                 return
-            ostree.extract_subpath(path, ref, "files/share", tmpdir)
+
+            dirs_needed = ("appdata", "metainfo", "app-info", "applications", "icons")
+
+            for subdir in dirs_needed:
+                os.makedirs(os.path.join(tmpdir, subdir), exist_ok=True)
+
+            for subdir in dirs_needed:
+                ostree.extract_subpath(
+                    path, ref, f"files/share/{subdir}", os.path.join(tmpdir, subdir), True
+                )
+
             self._validate(tmpdir, appid)

--- a/flatpak_builder_lint/checks/screenshots.py
+++ b/flatpak_builder_lint/checks/screenshots.py
@@ -20,7 +20,15 @@ class ScreenshotsCheck(Check):
         refs = ostree.get_refs(path, None)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            ostree.extract_subpath(path, ref, "files/share", tmpdir)
+            dirs_needed = ("appdata", "metainfo", "app-info")
+
+            for subdir in dirs_needed:
+                os.makedirs(os.path.join(tmpdir, subdir), exist_ok=True)
+
+            for subdir in dirs_needed:
+                ostree.extract_subpath(
+                    path, ref, f"files/share/{subdir}", os.path.join(tmpdir, subdir), True
+                )
 
             appstream_path = f"{tmpdir}/app-info/xmls/{appid}.xml.gz"
             if not os.path.exists(appstream_path):


### PR DESCRIPTION
We have to ignore the "directories not existing in the refs"-type errors now as we don't know if they do but if the don't, the repo check aborts with Glib exception, so `True` is passed to extract_subpath.

This should be fine as we don't depend on directories itself for checks but specific files existing or not existing inside those directories.