### PR TITLE
Remove OBS Studio finish-args-contains-both-x11-and-wayland exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1961,8 +1961,7 @@
         "finish-args-flatpak-spawn-access": "Required to be able to launch the modded Celeste game outside of the flatpak sandbox"
     },
     "com.obsproject.Studio": {
-        "finish-args-flatpak-spawn-access": "Required for the virtual camera feature",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+        "finish-args-flatpak-spawn-access": "Required for the virtual camera feature"
     },
     "io.github.thetumultuousunicornofdarkness.cpu-x": {
         "finish-args-flatpak-spawn-access": "access to /dev/cpu and /dev/mem is required in order to display data about CPU and memory"


### PR DESCRIPTION
If nothing requires us to revert the change, as of OBS 31 release the manifest use `fallback-x11` fixing the requirement of this exception.

Put as draft until 31 is out of beta/rc stage.