### PR TITLE
Add exception finish-args-contains-both-x11-and-wayland to fcitx

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1021,7 +1021,8 @@
         "finish-args-unnecessary-xdg-config-kxkbrc-rw-access": "Predates the linter rule",
         "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "Predates the linter rule",
         "finish-args-unnecessary-xdg-cache-ibus-create-access": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-config-ibus-create-access": "Predates the linter rule"
+        "finish-args-unnecessary-xdg-config-ibus-create-access": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Input method daemon need to talk with both XWayland/X11/Wayland applications at the same time"
     },
     "com.jetbrains.PyCharm-Community": {
         "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",


### PR DESCRIPTION
Unlike regular app, input method talks to all different type of display at the same time to support both Xwayland and Wayland app. fallback-x11 is not suitable for fcitx's usecase.