### PR TITLE
Add exceptions for Heroic and Lutris for umu access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1320,7 +1320,8 @@
     },
     "net.lutris.Lutris": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-umu-rw-access": "Uses shared installation for the umu runtime"
     },
     "net.retrodeck.retrodeck": {
         "finish-args-unnecessary-xdg-data-Steam-rw-access": "SteamOS is the primary target of the application and it does not ship an xsettings daemon or xdg-desktop-portal-gtk: https://github.com/ValveSoftware/SteamOS/issues/803",
@@ -3254,7 +3255,8 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "com.heroicgameslauncher.hgl": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-umu-rw-access": "Uses shared installation for the umu runtime"
     },
     "com.katawa_shoujo.KatawaShoujo": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
We want to share a single umu installation for all different game launcher, this exceptions allows that