### PR TITLE
Add exception for de.z_ray.OptimusUI for flatpak-spawn

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1203,6 +1203,9 @@
     "com.vscodium.codium-insiders": {
         "finish-args-flatpak-spawn-access": "needed to spawn several tools and command from host like podman, toolbox, compilers, etc"
     },
+    "de.z_ray.OptimusUI": {
+        "finish-args-flatpak-spawn-access": "Requires use of prime-select, nvidia-prime-select or fedora-prime-select on the host; Furthermore it requires access to /etc/os-release on the host to determine the real host distribution to use the correct prime tool and enable / disable features in the UI"
+    },
     "dev.boxi.Boxi": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },


### PR DESCRIPTION
As requested in: https://github.com/flathub/flathub/pull/5730#discussion_r1805698330

I hereby want to add an exception for de.z_ray.OptimusUI to allow access to flatpak-spawn because it is a wrapper UI for prime-select, nvidia-prime-select and fedora-prime-select which needs to be installed on the host system.  
In addition it also wants to read /etc/os-release on the host to access the correct prime tool and to enable / disable certain features in the UI depending on the prime tool in use.