### PR TITLE
Add finish-args-flatpak-spawn-access exception for io.github.lawstorant.boxflat

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3851,4 +3851,7 @@
     "org.freedesktop.Platform.VulkanInfo": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     }
+    "io.github.lawstorant.boxflat": {
+        "finish-args-flatpak-spawn-access": "Required for automatic per-game preset application based on process name"
+    }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3850,7 +3850,7 @@
     },
     "org.freedesktop.Platform.VulkanInfo": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    }
+    },
     "io.github.lawstorant.boxflat": {
         "finish-args-flatpak-spawn-access": "Required for automatic per-game preset application based on process name"
     }


### PR DESCRIPTION
Spawn access is required for automatic per-game preset application. This works by watching the running processes and applying a preset when a selected process name shows up.

Spawn access is needed to collect current process names.

In-app examples:
![image](https://github.com/user-attachments/assets/15733f64-0a47-4f78-a64f-49ed231c5a01)
![image](https://github.com/user-attachments/assets/55e521ed-e483-47b6-8769-0a27fe8db482)

