### PR TITLE
com.behringer.XAirEdit: Add linter exception for ~/.config/.X-AIR-Edit

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1551,6 +1551,7 @@
         "flathub-json-modified-publish-delay": "extra-data"
     },
     "com.behringer.XAirEdit": {
+        "finish-args-unnecessary-xdg-config-.X-AIR-Edit-create-access": "hardcoded path in application binary",
         "flathub-json-modified-publish-delay": "extra-data"
     },
     "com.bluejeans.BlueJeans": {


### PR DESCRIPTION
The application does not respect `$XDG_CONFIG_HOME` and always uses the path `~/.config/.X-AIR-Edit` (including the second dot) as the directory to put its configuration files in.

See <https://github.com/flathub/com.behringer.XAirEdit/pull/20> for a discussion about this.

We have asked the vendor to fix this behavior in
<https://ideas.behringer.com/p/x-air-edit-linux-version-does-not-respect-xdg_config_home>, but in the mean time, we'd like an exception for this so we no longer have to grant the application access to the whole home directory.