### PR TITLE
Sioyek needs access to configuration files under xdg-config/sioyek/

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3859,5 +3859,8 @@
     },
     "io.github.lawstorant.boxflat": {
         "finish-args-flatpak-spawn-access": "Required for automatic per-game preset application based on process name"
+    },
+    "com.github.ahrm.sioyek": {
+        "finish-args-unnecessary-xdg-config-sioyek-rw-access": "Required for app theming. Predates linter rule."
     }
 }


### PR DESCRIPTION
Sioyek uses his own directory xdg-config to look for the user theming configuration file "prefs_user.config". We need this to fix below bug: https://github.com/flathub/com.github.ahrm.sioyek/issues/24#issuecomment-2439694364