### PR TITLE
Add finish-args-flatpak-spawn-access exception for Kando

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3867,5 +3867,8 @@
     },
     "io.github.lawstorant.boxflat": {
         "finish-args-flatpak-spawn-access": "Required for automatic per-game preset application based on process name"
+    },
+    "menu.kando.Kando": {
+        "finish-args-flatpak-spawn-access": "Required because Kando is an app-launcher"
     }
 }


### PR DESCRIPTION
This adds the `finish-args-flatpak-spawn-access` exception for Kando as requested here: https://github.com/flathub/flathub/pull/5902.