### PR TITLE
Add Exception to Enable Tray Icon Support for `io.itch.itch`

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3463,7 +3463,8 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "io.itch.itch": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-wildcard-kde-own-name": "Still uses legacy StatusNotifier implementation"
     },
     "io.jamulus.Jamulus": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
This adds the `finish-args-wildcard-kde-own-name` exception for the `io.itch.itch` Flatpak. This application still uses Electron 22, which does not yet have the features needed to enable the tray icon without this permission. Once this is accepted, https://github.com/flathub/io.itch.itch/pull/27 can be merged by the maintainers.