### PR TITLE
Parse required-flatpak and enforce a minimum version for new metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends jq flatpak \
             desktop-file-utils elfutils flatpak-builder curl \
             dbus-daemon libgirepository1.0-dev \
-            gir1.2-ostree-1.0 gzip xmlstarlet libcairo2-dev
+            gir1.2-ostree-1.0 gzip xmlstarlet libcairo2-dev \
+            gir1.2-appstream-1.0
 
       - name: Setup Poetry
         run: |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ and on external tools.
 
 The following system dependencies must be installed:
 
-- `libgirepository1.0-dev, gir1.2-ostree-1.0`
+- `libgirepository1.0-dev, gir1.2-ostree-1.0, gir1.2-appstream-1.0`
 - `flatpak-builder` for validating flatpak-builder manifests
 - `appstreamcli` from `org.flatpak.Builder` for validating MetaInfo files
 ```sh
@@ -130,7 +130,7 @@ exec flatpak run --branch=stable --command=appstreamcli org.flatpak.Builder ${@}
 Debiab/Ubuntu:
 
 ```
-# apt install git appstream flatpak-builder libgirepository1.0-dev gir1.2-ostree-1.0 libcairo2-dev desktop-file-utils
+# apt install git appstream flatpak-builder libgirepository1.0-dev gir1.2-ostree-1.0 gir1.2-appstream-1.0 libcairo2-dev desktop-file-utils
 ```
 
 ArchLinux:

--- a/flatpak_builder_lint/builddir.py
+++ b/flatpak_builder_lint/builddir.py
@@ -42,6 +42,12 @@ def parse_metadata(builddir: str) -> dict:
     environment: dict = defaultdict(set)
     permissions: dict = defaultdict(set)
 
+    if (
+        key_file.has_group("Application")
+        and "required-flatpak" in key_file.get_keys("Application")[0]
+    ):
+        permissions["required-flatpak"] = key_file.get_value("Application", "required-flatpak")
+
     if key_file.has_group("Context"):
         for key in key_file.get_keys("Context")[0]:
             permissions[key] = key_file.get_string_list("Context", key)

--- a/tests/builddir/finish_args_new_metadata/metadata
+++ b/tests/builddir/finish_args_new_metadata/metadata
@@ -1,0 +1,6 @@
+[Application]
+name=org.flathub.finish_args_new_metadata
+runtime=org.freedesktop.Platform/x86_64/23.08
+
+[Context]
+devices=usb;

--- a/tests/manifests/finish_args-new-metadata.json
+++ b/tests/manifests/finish_args-new-metadata.json
@@ -1,0 +1,7 @@
+{
+    "app-id": "org.flathub.finish_args_new_metadata",
+    "finish-args": [
+        "--device=input",
+        "--require-version=1.11.0"
+    ]
+}

--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -165,6 +165,12 @@ def test_builddir_finish_args() -> None:
         assert not err.startswith(("finish-args-arbitrary-xdg-", "finish-args-unnecessary-xdg-"))
 
 
+def test_builddir_finish_args_new_metadata() -> None:
+    ret = run_checks("tests/builddir/finish_args_new_metadata")
+    found_errors = set(ret["errors"])
+    assert "finish-args-no-required-flatpak" in found_errors
+
+
 def test_builddir_display_supported() -> None:
     absents = {
         "finish-args-fallback-x11-without-wayland",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -182,6 +182,8 @@ def test_manifest_finish_args() -> None:
         "finish-args-absolute-run-media-path",
         "finish-args-has-nodevice-shm",
         "finish-args-has-nosocket-fallback-x11",
+        "finish-args-no-required-flatpak",
+        "finish-args-insufficient-required-flatpak",
     }
 
     ret = run_checks("tests/manifests/finish_args.json")
@@ -192,6 +194,12 @@ def test_manifest_finish_args() -> None:
         assert a not in found_errors
     for err in found_errors:
         assert not err.startswith(("finish-args-arbitrary-xdg-", "finish-args-unnecessary-xdg-"))
+
+
+def test_manifest_finish_args_new_metadata() -> None:
+    ret = run_checks("tests/manifests/finish_args-new-metadata.json")
+    found_errors = set(ret["errors"])
+    assert "finish-args-insufficient-required-flatpak" in found_errors
 
 
 def test_manifest_finish_args_issue_wayland_x11() -> None:


### PR DESCRIPTION
contingency plan if the fallback mechanism does not arrive in Flatpak 1.16.0