### PR TITLE
Add exceptions for new app io.github.flattool.Ignition

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3868,5 +3868,10 @@
     },
     "menu.kando.Kando": {
         "finish-args-flatpak-spawn-access": "Required because Kando is an app-launcher"
+    },
+    "io.github.flattool.Ignition": {
+        "finish-args-unnecessary-xdg-config-autostart-create-access": "This app's purpose is to manage autostart entries",
+        "finish-args-unnecessary-xdg-data-icons-ro-access": "Needed to be able to show app icons that are stored in this directory",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needed to be able to see the list of .desktop files associated with installed flatpaks, to be able to autostart them"
     }
 }


### PR DESCRIPTION
Add exceptions for this app to be able to see (read-only) .desktop files associated with flatpaks, see (read-only) app icons of installed applications, and make and edit (create) entries in the xdg autostart directory 