### PR TITLE
Add exception for net.imaginaryinfinity.Squiid

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3880,5 +3880,8 @@
         "finish-args-unnecessary-xdg-config-autostart-create-access": "This app's purpose is to manage autostart entries",
         "finish-args-unnecessary-xdg-data-icons-ro-access": "Needed to be able to show app icons that are stored in this directory",
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needed to be able to see the list of .desktop files associated with installed flatpaks, to be able to autostart them"
+    },
+    "net.imaginaryinfinity.Squiid": {
+        "finish-args-not-defined": "Is a command line application"
     }
 }


### PR DESCRIPTION
Due to some changes, Squiid no longer uses IPC and therefore no longer needs to access the network. This leaves us with no required permissions since this is a command line application