### PR TITLE
Drop linter exceptions for IRPF apps

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3778,15 +3778,6 @@
         "finish-args-unnecessary-xdg-config-openxr-create-access": "Required to set the current OpenXR runtime",
         "finish-args-flatpak-spawn-access": "Required to launch games on the host"
     },
-    "br.gov.fazenda.receita.irpf2022": {
-        "external-gitmodule-url-found": "Predates the linter rule"
-    },
-    "br.gov.fazenda.receita.irpf2023": {
-        "external-gitmodule-url-found": "Predates the linter rule"
-    },
-    "br.gov.fazenda.receita.irpf2024": {
-        "external-gitmodule-url-found": "Predates the linter rule"
-    },
     "org.freedesktop.LinuxAudio.BaseExtension": {
         "finish-args-not-defined": "This provides an extension point only",
         "toplevel-no-command": "This provides an extension point only",


### PR DESCRIPTION
This removes all `external-gitmodule-url-found` linter exceptions for IRPF apps.

Refs.:

\- IRPF 2022: https://github.com/flathub/br.gov.fazenda.receita.irpf2022/commit/931cb04c43e2954009418e70bf78bc118e2b7096
\- IRPF 2023: https://github.com/flathub/br.gov.fazenda.receita.irpf2023/commit/c9306168e971226147e0c7d35306e11250919828
\- IRPF 2024: https://github.com/flathub/br.gov.fazenda.receita.irpf2024/commit/af77e36aa5b0e89e88b741e17f9f642beac87ee4