### PR TITLE
update moonlight-installer exceptions to allow creating flatpak/overrides if it doesn't exist

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3860,7 +3860,8 @@
         "module-amc-data-checker-tracks-commits": "Uses tag"
     },
     "io.github.moonlight_mod.moonlight-installer": {
-        "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needed to set overrides and patch Flatpak installations of Discord",
+        "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needed to patch Flatpak installations of Discord",
+        "finish-args-unnecessary-xdg-data-flatpak-create-access": "Needed to set permission overrides",
         "finish-args-unnecessary-xdg-data-Discord-rw-access": "Needed to patch Discord",
         "finish-args-unnecessary-xdg-data-DiscordPTB-rw-access": "Needed to patch Discord PTB",
         "finish-args-unnecessary-xdg-data-DiscordCanary-rw-access": "Needed to patch Discord Canary",


### PR DESCRIPTION
for https://github.com/flathub/flathub/pull/6036#issuecomment-2600970954