### PR TITLE
Add exception for app.freelens.Freelens

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3872,5 +3872,8 @@
         "finish-args-unnecessary-xdg-data-DiscordCanary-rw-access": "Needed to patch Discord Canary",
         "finish-args-unnecessary-xdg-data-DiscordDevelopment-rw-access": "Needed to patch Discord Development",
         "finish-args-unnecessary-xdg-config-moonlight-mod-create-access": "Patches are stored here, needs to be accessible from all patched Discord instances"
+    },
+    "app.freelens.Freelens": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     }
 }


### PR DESCRIPTION
Exception for https://github.com/freelensapp/freelens

Reasons:

1. Freelens is not just UI for Kubernetes: it is also terminal application like org.kde.konsole or com.visualstudio.code. In the terminal you run your shell with your scripts from home directory then it'll be shell from the host then any command from the host.
2. Kubectl also needs a support for custom authentication. It must run any command that gets the token from the cloud provider: az, aws, gcloud, others. Basically, it might be any command from the host.


