### PR TITLE
docker: Set WORKDIR to $HOME

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,4 +16,5 @@ RUN ln -s /usr/bin/true /usr/bin/dbus-daemon
 ADD dbus-session.conf /app/share/dbus-1/session.conf
 
 USER flatbld
+WORKDIR /home/flatbld
 ENTRYPOINT ["/app/bin/flatpak-builder-lint"]


### PR DESCRIPTION
otherwise flatpak-builder tries to initiate ccache.conf inside / but this runs as user