### PR TITLE
Add exception for com.github.rafostar.Clapper

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -633,7 +633,8 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "com.github.rafostar.Clapper": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "manifest-has-bundled-extension": "Required to bundle its own plugins"
     },
     "com.github.raibtoffoletto.litteris": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",


### PR DESCRIPTION
Allow to bundle an extension

As discussed in https://github.com/flathub/flathub/pull/6106
Corresponding PR that adds said bundle to Clapper manifest: https://github.com/flathub/com.github.rafostar.Clapper/pull/36

ping @bbhtt 