### PR TITLE
Add rw access to xdg-data/icons for dev.heppen.webapps

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3945,6 +3945,7 @@
     },
     "dev.heppen.webapps": {
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Access for reading installed browsers",
-        "finish-args-unnecessary-xdg-data-applications-rw-access": "Access for writing desktop files for web apps"
+        "finish-args-unnecessary-xdg-data-applications-rw-access": "Access for writing desktop files for web apps",
+        "finish-args-unnecessary-xdg-data-icons-rw-access": "Access for writing icons into xdg-data/icons/QuickWebApps directory for created webapps"
     }
 }


### PR DESCRIPTION
Hey,

I need this exceptions for merge this PR: https://github.com/flathub/dev.heppen.webapps/pull/1

I need this permission because my app needs to write icons for created web apps. I tried to keep `xdg-data/icons` inside flatpak sandbox, but noticed this, some desktops (at least COSMIC) did not show icon for created app when desktop entry was pointing to `.var/app/../..` location. I don't know. It's just a fix. My app also have optional icon downloader so user will be able to download additional (Papirus) icon pack to use later with this app for creating web apps.