### PR TITLE
Add `finish-args-contains-both-x11-and-wayland` exception for Discord

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2009,7 +2009,8 @@
     },
     "com.discordapp.Discord": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule"
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
     },
     "com.discordapp.DiscordCanary": {
         "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients are forced to update"


### PR DESCRIPTION
The client currently crashes if `--socket=wayland` and `--socket=fallback-x11` are used.

See https://github.com/flathub/com.discordapp.Discord/pull/492