### PR TITLE
Draft: Add xdg-data exception for io.dbeaver.DBeaverCommunity

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -10,6 +10,9 @@
     "org.flathub.exceptions_wildcard": {
         "*": "ignore all errors and warnings"
     },
+    "io.dbeaver.DBeaverCommunity": {
+        "finish-args-unnecessary-xdg-data-DBeaverData-rw-access": "Required to be retro-compatible with old configurations (before migrating to XDG_DATA_HOME)"
+    },
     "page.codeberg.libre_menu_editor.LibreMenuEditor": {
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "this program needs write-access to xdg-data/applications and read-access to xdg-data/flatpak",
         "finish-args-unnecessary-xdg-data-applications-create-access": "this program needs write-access to xdg-data/applications and read-access to xdg-data/flatpak",


### PR DESCRIPTION
Hi everyone,

With @Eonfge, we are currently moving DBeaver configration data to XDG_DATA dirs in order to enforce app sandboxing.

However, because this is literally a breaking change (the config data is fetched from another place), I have created a little script that moves data from old config dir to the new one. This is why I still need access to the good old `xdg-data/DBeaverData` directory.

See https://github.com/flathub/io.dbeaver.DBeaverCommunity/pull/297 for more information

<br>

> [!NOTE]  
> This PR is in "Draft" state because I want @Eonfge to agree with this initiative