### PR TITLE
update Quick Web Apps permissions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4059,8 +4059,9 @@
     },
     "dev.heppen.webapps": {
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Access for reading installed browsers",
-        "finish-args-unnecessary-xdg-data-applications-rw-access": "Access for writing desktop files for web apps",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Access for writing desktop files for web apps",
         "finish-args-unnecessary-xdg-data-icons-rw-access": "Access for writing icons into xdg-data/icons/QuickWebApps directory for created webapps",
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "For COSMIC desktop environment",
         "finish-args-flatpak-system-folder-access": "Predates the linter rule"
     },
     "com.valvesoftware.Steam.CompatibilityTool.Proton-Exp": {


### PR DESCRIPTION
Hello,

Please update those exceptions for Quick Web Apps.

I changed `rw` access for `xdg-data/applications` to `create`, because some distros comes without this directory created at the beginning so we will create it if not exists.

About `xdg-config/cosmic rw`, this is needed for COSMIC environment for following system themes.

I will push those changes soon in my flathub's repo.