### PR TITLE
Add exception for io.gitlab.payoliin.csnake

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7,7 +7,7 @@
         "toplevel-no-command": "another nonsensical reason",
         "flathub-json-deprecated-i386-arch-included": "this would be a warning but is also skipped"
     },
-     "io.gitlab.payoliin.CSnake": {
+     "io.gitlab.payoliin.csnake": {
         "finish-args-not-defined": "Not needed as this app is fully terminal-based"
     },
     "org.flathub.exceptions_wildcard": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7,6 +7,9 @@
         "toplevel-no-command": "another nonsensical reason",
         "flathub-json-deprecated-i386-arch-included": "this would be a warning but is also skipped"
     },
+     "io.gitlab.payoliin.CSnake": {
+        "finish-args-not-defined": "Not needed as this app is fully terminal-based"
+    },
     "org.flathub.exceptions_wildcard": {
         "*": "ignore all errors and warnings"
     },


### PR DESCRIPTION
[CSnake is an app in the process of being submitted to Flathub.](https://github.com/flathub/flathub/pull/6243)

However, because it's a TUI-based app, it is launched with `Terminal=true`, so graphical permissions are not needed