### PR TITLE
appstream: Drop querying for metadata tag

### DIFF
--- a/flatpak_builder_lint/appstream.py
+++ b/flatpak_builder_lint/appstream.py
@@ -165,9 +165,7 @@ def get_screenshot_images(path: str) -> list[str]:
 
 
 def get_manifest_key(path: str) -> list[str]:
-    return xpath_list(path, "//custom/value[@key='flathub::manifest']/text()") + xpath_list(
-        path, "//metadata/value[@key='flathub::manifest']/text()"
-    )
+    return xpath_list(path, "//custom/value[@key='flathub::manifest']/text()")
 
 
 # String returns


### PR DESCRIPTION
This was dropped for flat-manager-hooks a while back. See https://github.com/flathub-infra/flat-manager-hooks/commit/a7a987098b1b8bda08ca243b8ce1883678f0c26e and https://github.com/flathub-infra/flat-manager-hooks/commit/6d2b2a12aa38778dfba5afad56752e1125911bc3