### PR TITLE
Support checking multiple primary refs sharing same ref id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,13 @@ jobs:
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/${{ env.FP_ARCH }} builddir/files/share/app-info/media
           ostree refs --repo=repo
           flatpak run --command=flatpak-builder-lint org.flatpak.Builder//localtest --exceptions --ref app/org.flathub.gui/${{ env.FP_ARCH }}/master repo repo
+          output=$(flatpak run --command=flatpak-builder-lint org.flatpak.Builder//localtest --exceptions repo repo | jq -r '.errors[] | select(. == "desktop-file-exec-key-absent")')
+          if [ "$output" = "desktop-file-exec-key-absent" ]; then
+            echo "PASS"
+          else
+            echo "FAIL: $output"
+            exit 1
+          fi
 
   docker-call:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,8 @@ jobs:
             --install-deps-from=flathub --ccache builddir org.flathub.gui.yaml
           sed -i "s/org\.flathub\.gui/com\.foo\.bar/g" org.flathub.gui.metainfo.xml org.flathub.gui.yaml org.flathub.gui.desktop
           cp -vf org.flathub.gui.desktop com.foo.bar.desktop
+          # Break the desktop file to raise an error
+          sed -i '/^Exec=/d' com.foo.bar.desktop
           cp -vf org.flathub.gui.metainfo.xml com.foo.bar.metainfo.xml
           cp -vf org.flathub.gui.png com.foo.bar.png
           dbus-run-session flatpak run org.flatpak.Builder --verbose --user --force-clean \

--- a/flatpak_builder_lint/checks/__init__.py
+++ b/flatpak_builder_lint/checks/__init__.py
@@ -21,8 +21,8 @@ class Check(metaclass=CheckMeta):
     appstream: ClassVar[set[str]] = set()
     desktopfile: ClassVar[set[str]] = set()
     info: ClassVar[set[str]] = set()
-    repo_primary_ref: str | None = None
+    repo_primary_refs: ClassVar[set[str]] = set()
 
-    def _populate_ref(self, repo: str) -> None:
-        if self.repo_primary_ref is None:
-            self.repo_primary_ref = ostree.get_primary_ref(repo)
+    def _populate_refs(self, repo: str) -> None:
+        if not Check.repo_primary_refs:
+            Check.repo_primary_refs.update(ostree.get_primary_refs(repo))

--- a/flatpak_builder_lint/checks/appid.py
+++ b/flatpak_builder_lint/checks/appid.py
@@ -107,10 +107,11 @@ class AppIDCheck(Check):
         self._validate(appid, ref_type != "app")
 
     def check_repo(self, path: str) -> None:
-        self._populate_ref(path)
-        ref = self.repo_primary_ref
-        if not ref:
+        self._populate_refs(path)
+        refs = self.repo_primary_refs
+        if not refs:
             return
-        appid = ref.split("/")[1]
 
-        self._validate(appid, False)
+        for ref in refs:
+            appid = ref.split("/")[1]
+            self._validate(appid, False)

--- a/flatpak_builder_lint/checks/desktop.py
+++ b/flatpak_builder_lint/checks/desktop.py
@@ -231,17 +231,18 @@ class DesktopfileCheck(Check):
         self._validate(f"{path}/files/share", appid)
 
     def check_repo(self, path: str) -> None:
-        self._populate_ref(path)
-        ref = self.repo_primary_ref
-        if not ref:
+        self._populate_refs(path)
+        refs = self.repo_primary_refs
+        if not refs:
             return
-        appid = ref.split("/")[1]
+        for ref in refs:
+            appid = ref.split("/")[1]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            for subdir in ("app-info", "applications", "icons"):
-                os.makedirs(os.path.join(tmpdir, subdir), exist_ok=True)
-                ostree.extract_subpath(
-                    path, ref, f"files/share/{subdir}", os.path.join(tmpdir, subdir), True
-                )
+            with tempfile.TemporaryDirectory() as tmpdir:
+                for subdir in ("app-info", "applications", "icons"):
+                    os.makedirs(os.path.join(tmpdir, subdir), exist_ok=True)
+                    ostree.extract_subpath(
+                        path, ref, f"files/share/{subdir}", os.path.join(tmpdir, subdir), True
+                    )
 
-            self._validate(tmpdir, appid)
+                self._validate(tmpdir, appid)

--- a/flatpak_builder_lint/checks/eolruntime.py
+++ b/flatpak_builder_lint/checks/eolruntime.py
@@ -31,15 +31,16 @@ class EolRuntimeCheck(Check):
         self._validate(runtime_ref)
 
     def check_repo(self, path: str) -> None:
-        self._populate_ref(path)
-        ref = self.repo_primary_ref
-        if not ref:
+        self._populate_refs(path)
+        refs = self.repo_primary_refs
+        if not refs:
             return
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ostree.extract_subpath(path, ref, "/metadata", tmpdir)
-            runtime_ref = builddir.get_runtime(tmpdir)
-            if not runtime_ref:
-                return
+        for ref in refs:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                ostree.extract_subpath(path, ref, "/metadata", tmpdir)
+                runtime_ref = builddir.get_runtime(tmpdir)
+                if not runtime_ref:
+                    return
 
-            self._validate(runtime_ref)
+                self._validate(runtime_ref)

--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -328,19 +328,20 @@ class FinishArgsCheck(Check):
         self._validate(appid, permissions)
 
     def check_repo(self, path: str) -> None:
-        self._populate_ref(path)
-        ref = self.repo_primary_ref
-        if not ref:
+        self._populate_refs(path)
+        refs = self.repo_primary_refs
+        if not refs:
             return
-        appid = ref.split("/")[1]
+        for ref in refs:
+            appid = ref.split("/")[1]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ostree.extract_subpath(path, ref, "/metadata", tmpdir)
-            metadata = builddir.parse_metadata(tmpdir)
-            if not metadata:
-                return
-            permissions = metadata.get("permissions", {})
-            if not (permissions or appid.endswith(config.FLATHUB_BASEAPP_IDENTIFIER)):
-                self.errors.add("finish-args-not-defined")
-                return
-            self._validate(appid, permissions)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                ostree.extract_subpath(path, ref, "/metadata", tmpdir)
+                metadata = builddir.parse_metadata(tmpdir)
+                if not metadata:
+                    return
+                permissions = metadata.get("permissions", {})
+                if not (permissions or appid.endswith(config.FLATHUB_BASEAPP_IDENTIFIER)):
+                    self.errors.add("finish-args-not-defined")
+                    return
+                self._validate(appid, permissions)

--- a/flatpak_builder_lint/checks/flathub_json.py
+++ b/flatpak_builder_lint/checks/flathub_json.py
@@ -81,19 +81,21 @@ class FlathubJsonCheck(Check):
         self._validate(appid, flathub_json, is_extra_data, ref_type != "app")
 
     def check_repo(self, path: str) -> None:
-        self._populate_ref(path)
-        ref = self.repo_primary_ref
-        if not ref:
+        self._populate_refs(path)
+        refs = self.repo_primary_refs
+        if not refs:
             return
-        appid = ref.split("/")[1]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ostree.extract_subpath(path, ref, "/metadata", tmpdir)
-            metadata = builddir.parse_metadata(tmpdir)
-            if not metadata:
-                return
-            flathub_json = ostree.get_flathub_json(path, ref, tmpdir)
-            if not flathub_json:
-                return
-            is_extra_data = bool(metadata.get("extra-data", False))
-            self._validate(appid, flathub_json, is_extra_data, False)
+        for ref in refs:
+            appid = ref.split("/")[1]
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                ostree.extract_subpath(path, ref, "/metadata", tmpdir)
+                metadata = builddir.parse_metadata(tmpdir)
+                if not metadata:
+                    return
+                flathub_json = ostree.get_flathub_json(path, ref, tmpdir)
+                if not flathub_json:
+                    return
+                is_extra_data = bool(metadata.get("extra-data", False))
+                self._validate(appid, flathub_json, is_extra_data, False)

--- a/flatpak_builder_lint/cli.py
+++ b/flatpak_builder_lint/cli.py
@@ -191,10 +191,9 @@ def main() -> int:
         "--ref",
         help="Override the primary ref detection",
         type=str,
-        nargs=1,
-        default=None,
+        action="append",
+        default=[],
     )
-
     parser.add_argument(
         "type",
         help=textwrap.dedent("""\
@@ -224,7 +223,7 @@ def main() -> int:
     path = os.getcwd() if args.cwd else args.path[0]
 
     if args.ref:
-        checks.Check.repo_primary_ref = args.ref[0]
+        checks.Check.repo_primary_refs = set(args.ref)
 
     if args.type != "appstream":
         if results := run_checks(

--- a/flatpak_builder_lint/ostree.py
+++ b/flatpak_builder_lint/ostree.py
@@ -43,21 +43,24 @@ def get_all_refs_filtered(repo_path: str) -> set[str]:
     }
 
 
-def get_primary_ref(repo_path: str) -> str | None:
-    refs = get_refs(repo_path, None)
-
-    ref: str
-
-    for ref in refs:
-        if ref.startswith("app/"):
-            return ref
-
-    return None
+def get_primary_refs(repo_path: str) -> set[str]:
+    return {
+        r
+        for r in get_refs(repo_path, None)
+        if (parts := r.split("/"))
+        and len(parts) == 4
+        and parts[0] == "app"
+        and parts[2] in config.FLATHUB_SUPPORTED_ARCHES
+    }
 
 
 def infer_appid(path: str) -> str | None:
-    ref = get_primary_ref(path)
-    if ref:
+    refs = get_primary_refs(path)
+    if refs:
+        # Assume refs share the same ref_id
+        # refs with different ref_id in a
+        # single repo is not a supported case
+        ref = next(iter(refs))
         return ref.split("/")[1]
 
     return None


### PR DESCRIPTION
A repo can contain more than one "app" ref, we should be checking
all of them not just the first one as the content in them might differ
in atypical setups.

This also helps to reduce an extra linter run on "per arch" repos. The
assumption is that multiple app refs will share the same ref id