### PR TITLE
Add host dconf exception for Ungoogled Chromium

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3531,6 +3531,8 @@
     },
     "io.github.ungoogled_software.ungoogled_chromium": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Access host dconf for proxy resolution",
+        "finish-args-direct-dconf-path": "Access host dconf for proxy resolution",
         "manifest-has-bundled-extension": "Predates the linter rule"
     },
     "io.gitlab.o20.word": {


### PR DESCRIPTION
I can't rely on xdg portals for system proxy due to https://github.com/flatpak/xdg-desktop-portal/issues/554. I had to drop the patch adding support for that to fix bugs with proxy extensions and some proxy related CLI arguments not working.

Now I need access to host dconf similar to other Chromium browsers like Brave, Chrome and Edge.