### PR TITLE
Add host tmp exception for Ungoogled Chromium

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3533,6 +3533,7 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-dconf-talk-name": "Access host dconf for proxy resolution",
         "finish-args-direct-dconf-path": "Access host dconf for proxy resolution",
+        "finish-args-host-tmp-access": "Access host tmp for MPRIS media cover art",
         "manifest-has-bundled-extension": "Predates the linter rule"
     },
     "io.gitlab.o20.word": {


### PR DESCRIPTION
In Chromium-based browsers, album art and video covers are stored in a temporary directory at `/tmp/.org.chromium.Chromium.<random_id>`. This path is then shared via the DBus property `org.mpris.MediaPlayer2.Player.Metadata`.

However, the `/tmp/` directory is not shared between the host and the Flatpak's namespace, preventing the host's notification area from displaying images in media controls.

Making the host's `/tmp/` directory writable resolves this issue.

https://github.com/flathub/com.brave.Browser/issues/750#issue-2921953257