### PR TITLE
Add exception for net.krafting.SemantiK

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4249,5 +4249,8 @@
     },
     "io.github.piotrek_k._2dTaskBoard": {
         "appid-url-not-reachable": "Repo is 2dTaskBoard but appstream expects leading underscore, manually verified"
+    },
+    "net.krafting.SemantiK": {
+        "manifest-has-bundled-extension": "Required to bundle the default language pack."
     }
 }


### PR DESCRIPTION
Hello,

I hope I did this right. This adds an exception for net.krafting.SemantiK, which will bundle its default language pack : net.krafting.SemantiK.Lang.French

See https://github.com/flathub/net.krafting.SemantiK/pull/16