### PR TITLE
net.nymtech.NymVPN: add var access exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1373,6 +1373,9 @@
     "io.stoplight.studio": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "net.nymtech.NymVPN": {
+        "finish-args-host-var-access": "needed to access the daemon logs"
+    },
     "net.codelogistics.webapps": {
         "finish-args-arbitrary-xdg-data-rw-access": "The app creates and removes desktop files in ~/.local/share/applications."
     },


### PR DESCRIPTION
Adds an exception to allow `/var/log` access.

NymVPN app is a GUI client for the `nym-vpnd` daemon.
In order to ease user bug reports, I added in the app an action to open daemon logs, using `xdg-open` to spawn the file manager at the logs' directory path.
Those logs are located under `/var/log/nym-vpnd/` so `--filesystem=/var/log/nym-vpnd:ro` is needed.