### PR TITLE
Add io.github.TeamWheelWizard.WheelWizard to exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,10 @@
 {
+    "io.github.TeamWheelWizard.WheelWizard": {
+        "finish-args-unnecessary-xdg-config-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin config files (e.g. for graphics settings)",
+        "finish-args-unnecessary-xdg-data-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin Mii and game/mod data files",
+        "finish-args-flatpak-appdata-folder-access": "this program needs to be able to access the Dolphin Flatpak's config and data directories for configuration and Mii/mod management",
+        "finish-args-flatpak-spawn-access": "this program needs to be able to run host commands as specified in the manifest's wrapper scripts to support Flatpak and native Dolphin installations"
+    },
     "io.github.mhogomchungu.sirikali": {
         "finish-args-flatpak-spawn-access": "this app is a front end to gocryptfs,securefs and cryfs. These tools do folder based encryption and they depend on fusermount located at /bin to mount and unmount their file systems"
     },


### PR DESCRIPTION
Related PR against `new-pr` on `flathub`: https://github.com/flathub/flathub/pull/6364

Wheel Wizard is supposed to support and manage the Dolphin Emulator for different types of installations: the `org.DolphinEmu.dolphin-emu` Flatpak on `flathub` or a native installation on the host. This is why there is a need to be able to spawn host `dolphin-emu` commands (given it's in the `PATH` of course) and also `flatpak` to launch the Dolphin Flatpak (see the wrapper scripts in the `flathub` PR).

Why we need these exceptions:
- `finish-args-unnecessary-xdg-config-dolphin-emu-rw-access`: Wheel Wizard needs to be able to read the Dolphin config of a host Dolphin installation and modify it since this is a feature of the GUI application.
- `finish-args-unnecessary-xdg-data-dolphin-emu-rw-access`: Wheel Wizard needs to be able to read the Dolphin application data of a host Dolphin installation and also modify it (game/mod or even Mii data).
- `finish-args-flatpak-appdata-folder-access`: Wheel Wizard also needs to be able to access the Dolphin Flatpak's `config` and `data` `dolphin-emu` subdirectories to manage and launch the Dolphin Flatpak installation correctly. We tried to still keep these filesystem permissions as restrictive as possible, supporting all common configurations, but nothing more.
- `finish-args-flatpak-spawn-access`: Wheel Wizard uses wrapper scripts as specified in the manifest to call the aforementioned host binaries. The upstream project's code does not call or even need `flatpak-spawn` commands since we utilize these wrapper scripts.