### PR TITLE
Added exception for io.github.limo_app.limo

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3909,7 +3909,8 @@
         "flathub-json-automerge-enabled": "Verified application"
     },
     "io.github.limo_app.limo": {
-        "finish-args-flatpak-spawn-access": "Required for running user defined modding tools, which take the form of arbitrary commands to be run on the host"
+        "finish-args-flatpak-spawn-access": "Required for running user defined modding tools, which take the form of arbitrary commands to be run on the host",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule. Required for accessing apps installed to the default directory by Flatpak Steam"
     },
     "io.github.wivrn.wivrn": {
         "finish-args-unnecessary-xdg-config-openvr-create-access": "Required to set the current OpenVR runtime",


### PR DESCRIPTION
The `finish-args-flatpak-appdata-folder-access` has been added to `io.github.limo_app.limo`. Access to `~/.var` predates the linter rule and is needed to access the Flatpak directory of Steam in order to allow the user to mod games installed to Steam's default library folder.

While access to `~/. var/app/com.valvesoftware.Steam` can be added manually by the user if needed, it is granted by default mainly to better support the Steam Deck. Almost all Steam Deck users use Flatpak Steam, and many are not familiar with Flatpak or even Linux in general.