### PR TITLE
Added exception for org.azahar_emu.Azahar

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2850,6 +2850,9 @@
     "org.apache.netbeans": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
+    "org.azahar_emu.Azahar": {
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Azahar has a feature which creates .desktop files in ~/.local/share/applications"
+    },
     "org.chrisoft.qmidiplayer": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },


### PR DESCRIPTION
For reasons that are beyond the scope of this PR, Lime3DS (which is already on Flathub) is being superseded by a new project named Azahar, and Lime3DS has been discontinued.
Lime3DS has an exception for `finish-args-unnecessary-xdg-data-applications-create-access` because of a feature which allows creating .desktop shortcuts for games, and as Azahar has the same feature, that exception is also required here.
The `org.freedesktop.portal.DynamicLauncher` portal is not appropriate here, as the feature allows the user to choose between creating the shortcut in the applications list or on the desktop.

See https://github.com/flathub/flathub/pull/6304 and #466.