### PR TITLE
Add exceptions for dev.geopjr.Turntable

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4273,5 +4273,13 @@
     },
     "io.github.ilya_zlobintsev.LACT": {
         "finish-args-flatpak-spawn-access": "Required to set up the host service for GPU control."
+    },
+    "dev.geopjr.Turntable": {
+        "finish-args-freedesktop-dbus-talk-name": "Required to gather and update the list of all available MPRIS clients",
+        "finish-args-flatpak-appdata-folder-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",
+        "finish-args-host-var-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
+        "finish-args-flatpak-system-folder-access": "Required to read .desktop files and icons for listing MPRIS clients"
     }
 }


### PR DESCRIPTION
rel: https://github.com/flathub/flathub/pull/6394

- `org.freedesktop.DBus` is used here https://codeberg.org/GeopJr/Turntable/src/commit/b9f4e07b0ed7b0ecd1349f7cd1690a81a06ecec3/src/Mpris/Manager.vala to [gather all MPRIS players](https://codeberg.org/GeopJr/Turntable/src/commit/b9f4e07b0ed7b0ecd1349f7cd1690a81a06ecec3/src/Mpris/Manager.vala#L14-L18) at the start and then [listen for ownership changes](https://codeberg.org/GeopJr/Turntable/src/commit/b9f4e07b0ed7b0ecd1349f7cd1690a81a06ecec3/src/Mpris/Manager.vala#L20) to [update the list of players](https://codeberg.org/GeopJr/Turntable/src/commit/b9f4e07b0ed7b0ecd1349f7cd1690a81a06ecec3/src/Mpris/Manager.vala#L55-L62)
- the filesystem ones are for the MPRIS artUrls that are local, including flatpak MPRIS clients
- the flatpak and host-var filesystem ones are for MPRIS client .desktop files and icons (used for displaying the icons when listing them in-app)

We might require further exceptions down the line.

