### PR TITLE
Add exception for org.siril.Siril to access Flatpak interface

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4285,4 +4285,7 @@
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
         "finish-args-flatpak-system-folder-access": "Required to read .desktop files and icons for listing MPRIS clients"
     }
+    "org.siril.Siril": {
+        "finish-args-flatpak-spawn-access": "required to interact with third-party applications like astrometry.net for plate solving and other astronomical image processing workflows"
+    }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4284,7 +4284,7 @@
         "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
         "finish-args-flatpak-system-folder-access": "Required to read .desktop files and icons for listing MPRIS clients"
-    }
+    },
     "org.siril.Siril": {
         "finish-args-flatpak-spawn-access": "required to interact with third-party applications like astrometry.net for plate solving and other astronomical image processing workflows"
     }


### PR DESCRIPTION
Siril needs access to the Flatpak interface (--talk-name=org.freedesktop.Flatpak) to interact with third-party applications, particularly astrometry.net. 

This integration is essential for astronomical image processing workflows, allowing Siril to seamlessly use astrometry.net for plate solving (determining exact coordinates and orientation of astronomical images). 

This PR adds the necessary exception in exceptions.json to enable this cross-application functionality.