### PR TITLE
Brave Exceptions Changes

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2483,7 +2483,8 @@
         "flathub-json-automerge-enabled": "Predates the linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Access host tmp for MPRIS media cover art"
     },
     "app.lith.Lith": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2480,7 +2480,6 @@
         "finish-args-host-tmp-access": "Predates the linter rule"
     },
     "com.brave.Browser": {
-        "flathub-json-modified-publish-delay": "Allow setting the delay to 0 to ensure users get the latest version as soon as possible",
         "flathub-json-automerge-enabled": "Predates the linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-dconf-talk-name": "Predates the linter rule",


### PR DESCRIPTION
Remove unused rule exception and add a new exception.

-------

```
commit de5fa57ea51b8a45ec750f490a369707a0d90dcd
Author: rany <rany@riseup.net>
Date:   Fri May 2 15:46:47 2025 +0300

    Add host tmp exception for Brave Browser
    
    In Chromium-based browsers, album art and video covers are stored in a
    temporary directory at `/tmp/.org.chromium.Chromium.<random_id>`.
    This path is then shared via the DBus property `org.mpris.MediaPlayer2.Player.Metadata`.
    
    However, the `/tmp/` directory is not shared between the host and the Flatpak's
    namespace, preventing the host's notification area from displaying images in media controls.
    
    Making the host's `/tmp/` directory writable fixes this issue.
    
    https://github.com/flathub/com.brave.Browser/issues/750#issue-2921953257
    
    Signed-off-by: rany <rany@riseup.net>

commit b2e4975c30604f0ffbfcf4696aae1b68009731a4
Author: rany <rany@riseup.net>
Date:   Fri May 2 15:45:39 2025 +0300

    Drop unused flathub-json-modified-publish-delay for Brave Browser
    
    As this is no longer used after the migration to Vorarbeiter,
    we have removed it from the Brave flathub.json.
    
    Signed-off-by: rany <rany@riseup.net>
```