### PR TITLE
Add "both x11 & wayland" exception for dev.vencord.Vesktop

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4313,5 +4313,8 @@
     },
     "com.rioterm.Rio": {
         "finish-args-flatpak-spawn-access": "required to spawn the user's shell and other commands on the host system; it's the primary purpose of a terminal emulator"
+    },
+    "dev.vencord.Vesktop": {
+        "finish-args-contains-both-x11-and-wayland": "Running through native Wayland instead of X11 causes issues, but Wayland access is still needed for pipewire screen capturing"
     }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4315,6 +4315,6 @@
         "finish-args-flatpak-spawn-access": "required to spawn the user's shell and other commands on the host system; it's the primary purpose of a terminal emulator"
     },
     "dev.vencord.Vesktop": {
-        "finish-args-contains-both-x11-and-wayland": "Running through native Wayland instead of X11 causes issues, but Wayland access is still needed for pipewire screen capturing"
+        "finish-args-contains-both-x11-and-wayland": "Running through native Wayland instead of X11 causes issues for a considerable number of users, but Wayland access is still needed for pipewire screen capturing"
     }
 }


### PR DESCRIPTION
I listed some specific issues here https://github.com/flathub/dev.vencord.Vesktop/pull/55#issuecomment-2888697811 if it matters