### PR TITLE
Add spawn-access exception for Deja Dup

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4151,7 +4151,8 @@
         "finish-args-host-var-access": "Predates the linter rule"
     },
     "org.gnome.DejaDup": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+        "finish-args-flatpak-appdata-folder-access": "Users would expect that a full home backup would include flatpak application configuration and data",
+        "finish-args-flatpak-spawn-access": "Required to spawn fusermount, mounting the user's backup via FUSE"
     },
     "org.gnome.baobab": {
         "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"


### PR DESCRIPTION
Deja Dup is switching from restoring via a custom in-app backup browser to mounting the backup via FUSE and using the user's file manager. To do that, it needs to launch fusermount from the host.

(Deja Dup has other strong permissions like `--filesystem=host` but I don't see an existing exception around that...)