### PR TITLE
remove some exceptions for Octave

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1535,9 +1535,7 @@
         "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system"
     },
     "org.octave.Octave": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "org.openshot.OpenShot": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",


### PR DESCRIPTION
As of https://github.com/flathub/org.octave.Octave/pull/427 doesn't need the exceptions.

Keeping the `finish-args-flatpak-spawn-access` because I do not know what it is needed for.