### PR TITLE
Add manifest-has-bundled-extension exception for com.fightcade.Fightcade

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1672,7 +1672,8 @@
     },
     "com.fightcade.Fightcade": {
         "flathub-json-modified-publish-delay": "Client version must be in sync with server to function",
-        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function"
+        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function",
+        "manifest-has-bundled-extension": "Optional quality of life features implemented as Flatpak extension"
     },
     "com.flashforge.FlashPrint": {
         "flathub-json-modified-publish-delay": "extra-data",


### PR DESCRIPTION
We have some work happening adding quality of life features for SteamOS that we want to implement using an optional com.fightcade.Fightcade.steamos extension.