### PR TITLE
Add io.github.swordpuffin.wardrobe

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,6 +1,5 @@
 {
     "io.github.swordpuffin.wardrobe": {
-        "finish-args-flatpak-spawn-access": "needed to access host dconf configuration",
         "finish-args-dconf-talk-name": "needed to access host dconf configuration"
     },
     "io.github.TeamWheelWizard.WheelWizard": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,8 @@
 {
+    "io.github.swordpuffin.wardrobe": {
+        "finish-args-flatpak-spawn-access": "needed to access host dconf configuration",
+        "finish-args-dconf-talk-name": "needed to access host dconf configuration"
+    },
     "io.github.TeamWheelWizard.WheelWizard": {
         "finish-args-unnecessary-xdg-config-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin config files (e.g. for graphics settings)",
         "finish-args-unnecessary-xdg-data-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin Mii and game/mod data files",


### PR DESCRIPTION
The purpose of the permissions is to allow activating downloaded desktop themes inside of Wardrobe without the need of using an external utility.