### PR TITLE
Add io.github.rfrench3.scopebuddy-gui

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "io.github.rfrench3.scopebuddy-gui": {
+        "finish-args-unnecessary-xdg-config-scopebuddy-create-access": "This program needs to be able to create and modify xdg-config/scopebuddy/scb.conf (edit config of host Scopebuddy)"
+    },
     "io.github.swordpuffin.wardrobe": {
         "finish-args-dconf-talk-name": "needed to access host dconf configuration"
     },


### PR DESCRIPTION
The permission is required to ensure the xdg-config/scopebuddy/scb.conf file exists and can be edited.