### PR TITLE
Add io.github.cosmicUtils.cosmicAppletMinimon with ro access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4293,5 +4293,8 @@
     },
     "io.github.debasish_patra_1987.linuxthemestore": {
         "finish-args-dconf-talk-name": "needed to access host dconf configuration for modifying themes"
+    },
+    "io.github.cosmicUtils.cosmicAppletMinimon": {
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
     }
 }


### PR DESCRIPTION
cosmic ro access is necessary to match expected functionality of an applet/app on Cosmic Desktop Environment