### PR TITLE
Add io.github.mpc_qt.mpc-qt

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6462,7 +6462,7 @@
         "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
     "io.github.mpc_qt.mpc-qt": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
         "finish-args-contains-both-x11-and-wayland": "The app supports both X11 and Wayland through a Tweaks setting"
     },
     "io.github.punesemu.puNES": {


### PR DESCRIPTION
Access to home folder is needed for external subtitles and for downloaded mouse cursor themes from legacy ~/.icons path.
See https://github.com/mpc-qt/mpc-qt/issues/470 and https://github.com/mpc-qt/mpc-qt/issues/437

The app supports both XWayland and Wayland through a Tweaks setting, but both mode currently have their limitations, so it's better to let the user choose.