### PR TITLE
desktop: Check if binary from Exec key exists in PATH (take 2)

### DIFF
--- a/tests/test_builddir.py
+++ b/tests/test_builddir.py
@@ -297,6 +297,7 @@ def test_builddir_desktop_file() -> None:
         "desktop-file-is-hidden",
         "desktop-file-exec-has-flatpak-run",
         "desktop-file-icon-not-installed",
+        "desktop-file-exec-not-found-in-bindir",
     }
     found_errors = set(ret["errors"])
     found_warnings: set[str] = set(ret["warnings"])
@@ -432,6 +433,7 @@ def test_min_success_metadata() -> None:
             create_catalogue(testdir, "org.flathub.gui.xml")
             create_app_icon(testdir, "org.flathub.gui.png")
             create_catalogue_icon(testdir, "org.flathub.gui.png")
+            create_file(os.path.join(testdir, "files/bin"), "Example")
 
         ret = run_checks(testdir)
         assert "errors" not in ret


### PR DESCRIPTION
The main problem here is the linter is running from "outside" of the target app, not inside its `flatpak run` or equivalent sandbox.

So using `GLib.find_program_in_path` will find the program in the "parent" env and always fail.

We need to use a worse alternative, something like `os.access(os.path.join(bin_path, executable), X.OK)` where `bin_path` is `<builddir>/files/bin` or `<path_to_extracted_repo>/files/bin` but that comes with its own set of issues.

We can extract from the exported repo, but the executable calculated inside it might be a symlink to something else somewhere. This quickly goes in the issue that we need to extract the entire ostree repo, and even then resolving symlinks may fail.

We have a lot of large apps and extracting the entire repo is not sustainable — we might run out of space.