### PR TITLE
Update StarryDex and Oboete permissions.

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4332,10 +4332,10 @@
         "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
     },
     "dev.mariinkys.Oboete": {
-        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
     },
     "dev.mariinkys.StarryDex": {
-        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
     },
     "org.gnome.Tomboy": {
         "finish-args-freedesktop-dbus-system-talk-name": "Predates the linter rule"


### PR DESCRIPTION
This PR adds write permission to dev.mariinkys.Oboete and dev.mariinkys.StarryDex to be able to write app configuration files. Similar to: https://github.com/flathub-infra/flatpak-builder-lint/pull/534