### PR TITLE
Add app.twintaillauncher.ttl exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,7 +1,6 @@
 {
     "app.twintaillauncher.ttl": {
-        "finish-args-home-filesystem-access": "The application is a game launcher, it lets users choose where to store games, wine/proton etc... on their file system.",
-        "appid-url-not-reachable": "Website is alive and actually accessible??? Why linter can not reach it is beyond me, perhaps some reverse proxy issues???"
+        "finish-args-home-filesystem-access": "The application is a game launcher, it lets users choose where to store games, wine/proton etc... on their file system."
     },
     "com.ml4w.dotfilesinstaller": {
         "finish-args-home-filesystem-access": "As the app is a dotfiles management tool, access to the home directory is required for the application's core functionality."

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,8 @@
 {
+    "app.twintaillauncher.ttl": {
+        "finish-args-home-filesystem-access": "The application is a game launcher, it lets users choose where to store games, wine/proton etc... on their file system.",
+        "appid-url-not-reachable": "Website is alive and actually accessible??? Why linter can not reach it is beyond me, perhaps some reverse proxy issues???"
+    },
     "com.ml4w.dotfilesinstaller": {
         "finish-args-home-filesystem-access": "As the app is a dotfiles management tool, access to the home directory is required for the application's core functionality."
     },


### PR DESCRIPTION
File system home permission exception was mentioned here: https://github.com/flathub/flathub/pull/6704#discussion_r2193806961

As said multiple times I am confused why it can not reach perfectly online website address but I hope it is fine to exception that one too. You can check website is online and alive by visiting https://twintaillauncher.app