### PR TITLE
Add exception for com.ntrack.ntrack: allow automerge

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6521,5 +6521,8 @@
     },
     "io.github.rimsort.RimSort": {
         "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the workshop rimworld file in Steam"
+    },
+    "com.ntrack.n-track": {
+        "flathub-json-automerge-enabled": "Required to preserve the app’s CI workflow"
     }
 }


### PR DESCRIPTION
Requesting linter exception for `com.ntrack.n-track`.

Exception requested:
- `flathub-json-automerge-enabled`: Automatic merging of PRs is required to preserve the app’s CI workflow
