### PR TITLE
Add `finish-args-contains-both-x11-and-wayland` exception for Avidemux

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5077,7 +5077,8 @@
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.avidemux.Avidemux": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Fixes a start up crash for some Wayland users"
     },
     "org.beeref.BeeRef": {
         "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
This seems to fix a start up crash affecting some Wayland users: https://github.com/flathub/org.avidemux.Avidemux/issues/29

We can't use `--socket=fallback-x11` at the moment, because that introduces a different start up crash (as detailed in the PR below)...

This is needed for: https://github.com/flathub/org.avidemux.Avidemux/pull/32