### PR TITLE
Add `finish-args-flatpak-system-folder-access` exception for SGDBoop

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3540,7 +3540,8 @@
     },
     "com.steamgriddb.SGDBoop": {
         "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Read-only access to /var/lib/flatpak/app/com.valvesoftware.Steam to check whether Steam Flatpak is installed"
     },
     "com.steamgriddb.steam-rom-manager": {
         "flathub-json-automerge-enabled": "Predates the linter rule",


### PR DESCRIPTION
SGDBoop needs read-only access to `/var/lib/flatpak/app/com.valvesoftware.Steam` to check if Steam was installed using Flatpak.

https://github.com/flathub/com.steamgriddb.SGDBoop/pull/22