### PR TITLE
Add `finish-args-host-filesystem-access` exception for Clapgrep

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6521,5 +6521,8 @@
     },
     "io.github.rimsort.RimSort": {
         "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the workshop rimworld file in Steam"
+    },
+    "de.leopoldluley.Clapgrep": {
+        "finish-args-host-filesystem-access": "Required to get real paths from the GTK FileDialog"
     }
 }


### PR DESCRIPTION
With read-only access, the GTK FileDialog still returns "Document API" style paths rather than the real path. This means Clapgrep can't display the actual path of the search directory or searched files. I don't understand why it only works with write access, but I would guess this is some kind of issue with Flatpak.

https://github.com/flathub/de.leopoldluley.Clapgrep/pull/15