### PR TITLE
Update execptions.json for org.remmina.Remmina

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3410,6 +3410,7 @@
     },
     "org.remmina.Remmina": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-spawn-access": "Needed to launch programs on the host specified by the user",
         "flathub-json-automerge-enabled": "Predates the linter rule",
         "finish-args-dconf-talk-name": "Predates the linter rule",
         "finish-args-direct-dconf-path": "Predates the linter rule",


### PR DESCRIPTION
Right now Remmina has several features that are broken in the flatpak release. The main one is launching programs the user specifies, either by themselves or as part of launching a remote connection. For example, a user might want to run a Wake-on-LAN command to wake up the box they want to connect to, or start up a VPN or an ssh tunnel to allow the connection to succeed. This permission change will allow these features to work.

@bbhtt, I think I did everything correctly here, but if I made a mistake or you need any more details please let me know. 