### PR TITLE
Add release-not-in-order exception for org.garudalinux.firedragon

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6492,6 +6492,9 @@
     "org.freedesktop.GstDebugViewer": {
         "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
+    "org.garudalinux.firedragon": {
+        "releases-not-in-order": "This project uses SemVer which differs from AppStream release order"
+    },
     "org.gnome.Evince": {
         "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },


### PR DESCRIPTION
The FireDragon project uses [SemVer](https://semver.org/) versioning and the releases in the MetaInfo are ordered accordingly (v12.0.0-beta.21 << v12.0.0-beta.21). But AppStream release order differs and thinks that v12.0.0 << v12.0.0-beta.21 (https://github.com/flathub-infra/vorarbeiter/actions/runs/17147357555/job/48646095336) which is wrong in SemVer. So I would like to request an exception for this linting rule to keep the currently sensible release order in MetaInfo.