### PR TITLE
Add exceptions for org.garudalinux.firedragon-catppuccin

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6398,6 +6398,9 @@
     "org.garudalinux.firedragon": {
         "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
     },
+    "org.garudalinux.firedragon-catppuccin": {
+        "finish-args-desktopfile-filesystem-access": "Required to manage desktop entries for installed PWAs"
+    },
     "org.kde.angelfish": {
         "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
     },


### PR DESCRIPTION
This adds exceptions for org.garudalinux.firedragon-catppuccin (in submission: https://github.com/flathub/flathub/pull/6874).

FireDragon requires access to `~/.local/share/applications` to automatically manage desktop entries for installed PWAs.