### PR TITLE
chore: Add Exception To Cosmicding

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6658,5 +6658,8 @@
     },
     "org.virt_manager.virt-viewer": {
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.vkhitrin.cosmicding": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
     }
 }


### PR DESCRIPTION
Adding `finish-args-unnecessary-xdg-config-cosmic-rw-access` exception
similar to other COSMIC-based applications.

Encountered in flathub/com.vkhitrin.cosmicding/pull/3
