### PR TITLE
Add exceptions for one.ablaze.floorp

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,8 @@
 {
+    "one.ablaze.floorp": {
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Needed for manually creating application .desktop files for Floorp's Web Apps feature",
+        "finish-args-unnecessary-xdg-data-icons-create-access": "Needed as Floorp's Web Apps feature downloads and installs icons for each website that the user adds",
+    },
     "io.github.swordpuffin.rewaita": {
         "finish-args-autostart-filesystem-access": "Needed for manually creating an autostart file with specific parameters which cannot be done through Libportal"
     },


### PR DESCRIPTION
Adds exceptions for one.ablaze.floorp.

Floorp requires `~/.local/share/applications` and `~/.local/share/icons` creation, editing and deletion access for its Web Apps feature to successfully install shortcuts, with icons, for websites the user picks to install.