### PR TITLE
Add finish-args-has-socket-ssh-auth for org.gitfourchette.gitfourchette

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1208,6 +1208,7 @@
     },
     "org.gitfourchette.gitfourchette": {
         "finish-args-flatpak-spawn-access": "Start external merge tool via flatpak-spawn",
+        "finish-args-has-socket-ssh-auth": "Authenticate with git remotes via host's ssh-agent",
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.fcitx.Fcitx5": {


### PR DESCRIPTION
Upcoming version 1.5.0 of [org.gitfourchette.gitfourchette](https://github.com/flathub/org.gitfourchette.gitfourchette) has gained support for using the host's ssh-agent to authenticate with git remotes, so `--socket=ssh-auth` was added to the manifest.