### PR TITLE
Add exceptions for io.github.BuddySirJava.SSH-Studio

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,8 @@
 {
+    "io.github.BuddySirJava.SSH-Studio": {
+        "finish-args-ssh-filesystem-access": "This app's main functionality is to edit ssh connections located in ~/.ssh/config",
+        "finish-args-has-socket-ssh-auth": "Needed for testing ssh connections (Located in HostEditor)"
+    },
     "io.github.swordpuffin.rewaita": {
         "finish-args-autostart-filesystem-access": "Needed for manually creating an autostart file with specific parameters which cannot be done through Libportal"
     },


### PR DESCRIPTION
Hello.
[SSH-Studio](https://github.com/BuddySirJava/SSH-Studio) is a GTK SSH config editor which edits and validates the `~/.ssh/config`. Also this app manages and generates SSH keys.
Also my app has a section which tests the configured ssh prefix for user in-app by spawning ssh command in a test dialog.
 
 These exceptions are needed since those are the core functionality of my app.
 
The app is yet to be submitted to Flathub [here](https://github.com/flathub/flathub/pull/6918).

Thanks for your time