### PR TITLE
Add exception to io.github.vikdevelop.SaveDesktop

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4496,6 +4496,7 @@
         "finish-args-legacy-icon-folder-permission": "Specifically meant to save desktop settings",
         "finish-args-legacy-font-folder-permission": "Specifically meant to save desktop settings",
         "finish-args-incorrect-theme-folder-permission": "Specifically meant to save desktop settings",
+        "finish-args-full-home-local-share-access": "Predates the linter rule",
         "finish-args-full-home-config-access": "Predates the linter rule"
     },
     "dev.bsnes.bsnes": {


### PR DESCRIPTION
This adds an exception for io.github.vikdevelop.SaveDesktop (in submission: https://github.com/flathub/flathub/pull/3951).

Save Desktop requests access to `finish-args-full-home-local-share-access` because it is necessary to ensure the correct and complete storage of desktop environment configurations, since the requested folder contains, e.g., user's wallpapers, GNOME Shell extensions, Nautilus scripts, etc.

I added the justification "Predates linter rule" because the application requested this permission long before this rule was created.