### PR TITLE
Add exceptions for io.github.shonubot.Spruce

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6938,5 +6938,10 @@
     },
     "life.bolls.bolls": {
         "finish-args-full-home-config-access": "Predates the linter rule"
+     },
+    "io.github.shonubot.Spruce": {
+        "finish-args-arbitrary-xdg-cache-rw-access": "Required to scan and clean app caches in $HOME/.cache, with user preview and confirmation.",
+        "finish-args-host-ro-filesystem-access": "Needed for accurate disk usage calculations using host mount info; cleaning is limited to user areas.",
+        "finish-args-flatpak-spawn-access": "Allows calling host tools for size checks and safe deletions, restricted to user-selected targets."
     }
 }


### PR DESCRIPTION
Spruce is a GTK4/libadwaita system cleaner that helps users reclaim disk space by scanning and removing application cache files.  
To support its core functionality.

**Requested exceptions:**
- finish-args-arbitrary-xdg-cache-rw-access  
  → Needed to scan and clean user application caches in $HOME/.cache with explicit preview and confirmation.

- finish-args-host-ro-filesystem-access  
  → Allows read-only inspection of host mount info to calculate accurate disk usage before/after cleaning.  
    Cleaning itself remains limited to user-writable locations.

- finish-args-flatpak-spawn-access  
  → Required to invoke host tools (du/find/stat, etc.) for size checks and safe deletions, restricted to user-selected targets.

These permissions are essential for Spruce’s purpose as a system optimiser.
The app is yet to be submitted to Flathub [here](https://github.com/flathub/flathub/pull/6922)