### PR TITLE
Add `finish-args-host-tmp-access` for Turntable

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4935,7 +4935,8 @@
         "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
         "finish-args-flatpak-system-folder-access": "Required to read .desktop files and icons for listing MPRIS clients",
-        "finish-args-full-home-cache-access": "Predates the linter rule"
+        "finish-args-full-home-cache-access": "Required to read the local MPRIS artUrl files from some MPRIS clients",
+        "finish-args-host-tmp-access": "Required to read the local MPRIS artUrl files from some MPRIS clients"
     },
     "org.siril.Siril": {
         "finish-args-flatpak-spawn-access": "required to interact with third-party applications like astrometry.net for plate solving and other astronomical image processing workflows",


### PR DESCRIPTION
Some MPRIS clients (specifically, all chromium-based browsers and I believe audacius too), use `/tmp` for storing the artUrl covers.\*

I also added a reason for the cache access exception (same as /tmp).

\* Not a decision taken lightly, I tried to avoid adding even more exceptions but I've received more than one report and e-mail about this.

rel: https://github.com/flathub/dev.geopjr.Turntable/pull/6