### PR TITLE
Update exception for io.github.DenysMb.Kontainer

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4958,7 +4958,10 @@
         "finish-args-own-name-de.allotropia.ZetaOfficeIpc0": "Predates the linter rule"
     },
     "io.github.DenysMb.Kontainer": {
-        "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host"
+        "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host",
+        "finish-args-flatpak-user-folder-access": "Needed to export and unexport apps",
+        "finish-args-desktopfile-filesystem-access": "Needed to find exported apps",
+        "finish-args-flatpak-system-folder-access": "Needed to find exported apps"
     },
     "io.github.bcpierce00.unison": {
         "finish-args-flatpak-appdata-folder-access": "Unison must be able to sync all the user's data or config files",

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4959,9 +4959,7 @@
     },
     "io.github.DenysMb.Kontainer": {
         "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host",
-        "finish-args-flatpak-user-folder-access": "Needed to export and unexport apps",
-        "finish-args-desktopfile-filesystem-access": "Needed to find exported apps",
-        "finish-args-flatpak-system-folder-access": "Needed to find exported apps"
+        "finish-args-desktopfile-filesystem-access": "Needed to list exported apps from distroboxes"
     },
     "io.github.bcpierce00.unison": {
         "finish-args-flatpak-appdata-folder-access": "Unison must be able to sync all the user's data or config files",


### PR DESCRIPTION
We added the functionality to export and unexport apps from distrobox directly from the app. We need these permissions so Kontainer would be able to list the exported apps.

<img width="718" height="548" alt="image" src="https://github.com/user-attachments/assets/358655db-2c20-4f05-8f2e-8417b1db6316" />