### PR TITLE
Override reading of avatar images

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6948,5 +6948,8 @@
     },
     "it.mq1.TinyWiiBackupManager": {
         "finish-args-host-filesystem-access": "Used for loading the rom dumps from anywhere in the home directory or from a drive, and for transferring them to the Wii drive."
+    },
+    "de.gonicus.gonnect": {
+        "finish-args-unnecessary-xdg-data-evolution-ro-access": "EDS exposes avatar images here, and GOnnect likes to display them on incoming calls."
     }
 }


### PR DESCRIPTION
Evolution Data Server references it's avatar images in the local file system, namely

```
  xdg-data/evolution/addressbook/system/photos
```

. We need access to the files placed there, in order to show them in various places (incoming call notifications, favorites, etc.).