### PR TITLE
Exclude home access from linter checks for GIMP

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1215,6 +1215,7 @@
         "finish-args-unnecessary-xdg-config-GIMP-create-access": "GIMP config always used",
         "finish-args-host-tmp-access": "Predates the linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "GIMP requires users to be able to save and open their projects from user home directory",
         "finish-args-kwin-talk-name": "Predates the linter rule"
     },
     "org.gitfourchette.gitfourchette": {


### PR DESCRIPTION
Exclude `home` access in finish-args from failing in GIMP project. Currently GIMP allows `host` access which is an overkill and insecure in terms of sandboxing. The linter does currently  allow `host` access as the permission predates linter rule. 

I will remove that later - if and when the PR to switch `host` to `home` gets accepted and merged in org.gimp.GIMP flathub repo.

Ref: https://github.com/flathub/org.gimp.GIMP/pull/523