### PR TITLE
app.devsuite.Manuals: update xdg-data exceptions for local doc access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1202,7 +1202,10 @@
         "finish-args-flatpak-system-talk-name": "application uses libflatpak install SDK documentation",
         "finish-args-flatpak-system-folder-access": "Predates the linter rule",
         "finish-args-flatpak-user-folder-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-gtk-doc-ro-access": "Manuals requires access to locally installed documentation",
+        "finish-args-unnecessary-xdg-data-doc-ro-access": "Manuals requires access to locally installed documentation",
+        "finish-args-unnecessary-xdg-data-devhelp-ro-access": "Manuals requires access to locally installed documentation"
     },
     "app.devsuite.Ptyxis": {
         "finish-args-flatpak-spawn-access": "application requires ptyxis-agent for PTY setup on host",


### PR DESCRIPTION
So that we can actually restrict things further than they were previously.

* https://gitlab.gnome.org/GNOME/manuals/-/commit/edd23f0ff3897e593a22dd1e99208484bbf99568
* https://github.com/flathub/app.devsuite.Manuals/pull/8