### PR TITLE
add finish-args-unnecessary-xdg-config-mimeapps.list-create-access for page.codeberg.libre_menu_editor.LibreMenuEditor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -68,7 +68,7 @@
         "finish-args-unnecessary-xdg-data-xdg-desktop-portal-ro-access": "for reading .desktop files and icons in xdg-data/xdg-desktop-portal",
         "finish-args-unnecessary-xdg-data-flatpak-ro-access": "for reading .desktop files and symlink targets in xdg-data/flatpak",
         "finish-args-unnecessary-xdg-data-applications-create-access": "for creating, reading, modifying, and deleting .desktop files in xdg-data/applications",
-        "finish-args-unnecessary-xdg-config-mimeapps.list-rw-access": "for reading and updating mimetypes in xdg-config/mimeapps.list",
+        "finish-args-unnecessary-xdg-config-mimeapps.list-create-access": "for reading and updating mimetypes in xdg-config/mimeapps.list",
         "finish-args-flatpak-spawn-access": "for reading environment variables on the host system",
         "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
         "finish-args-flatpak-system-folder-access": "Predates the linter rule",


### PR DESCRIPTION
This permission needs to be ```:create``` rather than ```:rw```, in case ```~/.config/mimeapps.list``` does not already exist on the user's system.