### PR TITLE
Add twintaillauncher exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,8 @@
 {
+    "app.twintaillauncher.ttl": {
+        "finish-args-desktopfile-filesystem-access": "Application can create .desktop file shortcuts for games... literally can not write those files without access to the folder",
+        "finish-args-flatpak-appdata-folder-access": "Application can write Steam shortcuts to its shortcuts.vdf file and it needs this to access flatpak Steam"
+    },
     "page.codeberg.cozyowl.OpaqueFiles": {
         "finish-args-host-filesystem-access": "Needed to encrypt, decrypt or check files in HOME and on mounted filesystems (USB, Network, ...)"
     },


### PR DESCRIPTION
This adds 2 exceptions my application needs to allow users to create game shortcuts under flatpak.

My application allowed making these shortcuts for a couple of versions and users are confused why they cant create shortcuts sometimes... I am really trying to avoid giving permissions that need exceptions to the maximum but the 2 i request with this pull request are necessary for the functionality of writing flatpak Steam shortcuts into shortcuts.vdf and .desktop files for desktop shortcuts for games.