### PR TITLE
Update exceptions.json for io.github.brunoherbelin.Vimix

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6377,5 +6377,8 @@
     },
     "it.mq1.TinyWiiBackupManager": {
         "finish-args-host-filesystem-access": "Used for loading the rom dumps from anywhere in the home directory or from a drive, and for transferring them to the Wii drive."
+    },
+    "io.github.brunoherbelin.Vimix": {
+        "finish-args-arbitrary-dbus-access": "Application needs access to session-bus to inhibit the desktop screensaver via the org.freedesktop.ScreenSaver D-Bus API (live performance)"
     }
 }


### PR DESCRIPTION
Application needs access to session-bus to inhibit the desktop screensaver via the org.freedesktop.ScreenSaver D-Bus API (live performance)