### PR TITLE
add exceptions for io.github.brunoherbelin.Vimix

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6377,5 +6377,8 @@
     },
     "it.mq1.TinyWiiBackupManager": {
         "finish-args-host-filesystem-access": "Used for loading the rom dumps from anywhere in the home directory or from a drive, and for transferring them to the Wii drive."
+    },
+    "io.github.brunoherbelin.Vimix": {
+        "finish-args-portal-talk-name": "Application needs access to talk-name=org.freedesktop.portal.Desktop to inhibit the desktop screensaver via the org.freedesktop.portal.Inhibit D-Bus API (live performance)"
     }
 }


### PR DESCRIPTION
Application needs access to talk-name=org.freedesktop.portal.Desktop to inhibit the desktop screensaver via the org.freedesktop.portal.Inhibit D-Bus API (live performance).