### PR TITLE
Add exception for com.github.wwmm.easyeffects

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -836,7 +836,8 @@
     },
     "com.github.wwmm.easyeffects": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Core application supports wayland natively, but simultaneously needs x11 access to show audio plugin windows."
     },
     "com.github.wwmm.pulseeffects": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",


### PR DESCRIPTION
Allow x11 and wayland support as x11 is needed for audio plugin windows, even though the application itself runs under Wayland.