### PR TITLE
Add exception for moe.launcher.an-anime-game-launcher

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "moe.launcher.an-anime-game-launcher": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
     "app.twintaillauncher.ttl": {
         "finish-args-desktopfile-filesystem-access": "Application can create .desktop file shortcuts for games... literally can not write those files without access to the folder",
         "finish-args-flatpak-appdata-folder-access": "Application can write Steam shortcuts to its shortcuts.vdf file and it needs this to access flatpak Steam"


### PR DESCRIPTION
Needed for Wine to be able to run on XWayland by default as intended by the Wine project, given that winewayland is still unstable.

See Bottles' example: https://github.com/flathub-infra/flatpak-builder-lint/blob/03f8008d97f291683830e2bd28dc1c886b274c95/flatpak_builder_lint/staticfiles/exceptions.json#L3451