### PR TITLE
Add D-Bus access for keyforge_master app

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6351,4 +6351,7 @@
     "it.mq1.TinyWiiBackupManager": {
         "finish-args-host-filesystem-access": "Used for loading the rom dumps from anywhere in the home directory or from a drive, and for transferring them to the Wii drive."
     }
+    "tech.keyforge.keyforge_master": {
+        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access",
+    },
 }


### PR DESCRIPTION
This app is a macropad configurator, it uses node serialport. It needs to have access to session bus to run