### PR TITLE
Allow Floorp to read Breeze GTK's colour scheme

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3687,7 +3687,8 @@
     "one.ablaze.floorp": {
         "finish-args-own-name-wildcard-org.mozilla.floorp": "Predates the linter rule",
         "finish-args-unnecessary-xdg-data-applications-create-access": "Needed for manually creating application .desktop files for Floorp's Web Apps feature",
-        "finish-args-unnecessary-xdg-data-icons-create-access": "Needed as Floorp's Web Apps feature downloads and installs icons for each website that the user adds"
+        "finish-args-unnecessary-xdg-data-icons-create-access": "Needed as Floorp's Web Apps feature downloads and installs icons for each website that the user adds",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "Needed for Breeze, etc. to use their colour scheme - upstream Firefox permission"
     },
     "org.b3log.siyuan": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
This is a change being imported from upstream Firefox - see https://github.com/mozilla-firefox/firefox/commit/d3396ccbb87ca0b9cf0e56c01eaa9f59a32d854f