### PR TITLE
Add exceptions for com.gitbutler.gitbutler

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5960,7 +5960,10 @@
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.gitbutler.gitbutler": {
-        "finish-args-ssh-filesystem-access": "Predates the linter rule"
+        "finish-args-has-socket-gpg-agent": "Needed to sign Git commits with GPG",
+        "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
+        "finish-args-host-filesystem-access": "Needed to access Git repositories outside the sandbox",
+        "finish-args-own-name-com.gitbutler.app": "Needed for D-Bus service registration"
     },
     "com.nomachine.nxplayer": {
         "finish-args-ssh-filesystem-access": "Predates the linter rule",


### PR DESCRIPTION
### GPG and SSH agent access

GitButler is a graphical Git client that requires SSH agent access for cloning repositories and GPG agent access for signing commits.

### Host filesystem access

Although the app can open Git repositories through the FileChooser portal, the bundled Git binary encounters critical errors when working with these directories (https://github.com/flathub/com.gitbutler.gitbutler/issues/33).

```
command: fetch_from_remotes
params: {"projectId":"8d19940a-52b5-4fd2-843b-d090fda151f7","action":"modal"})

backend error: git command exited with non-zero exit code 1: ["fetch", "--quiet", "--prune", "origin", "+refs/heads/*:refs/remotes/origin/*"]

STDERR:
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
fatal: Unable to read current working directory: No such file or directory
error: github.com:flathub/com.gitbutler.gitbutler.git did not send all necessary objects
fatal: Unable to read current working directory: No such file or directory
```

### Owner access to `com.gitbutler.app` session bus

The app requires `com.gitbutler.app` bus name to start. This is a requirement from the upstream developers, as discussed in https://github.com/flathub/com.gitbutler.gitbutler/pull/104#issuecomment-2621436691. Without this permission, the application fails to start with a fatal error (https://github.com/flathub/com.gitbutler.gitbutler/issues/111).

```
thread 'main' (2) panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tao-0.34.5/src/platform_impl/linux/event_loop.rs:218:53:
Failed to initialize gtk backend!: Error { domain: g-dbus-error-quark, code: 2, message: "GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown" }
```