### PR TITLE
Add new permissions for Kando

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3986,7 +3986,6 @@
     "menu.kando.Kando": {
         "finish-args-flatpak-spawn-access": "Required because Kando is an app-launcher",
         "finish-args-host-ro-filesystem-access": "Required for listing installed applications and icon themes",
-        "finish-args-home-ro-filesystem-access": "Required for listing installed applications and icon themes",
         "finish-args-kwin-talk-name": "Required to talk to a KWin script for getting the focused window name"
     },
     "io.github.flattool.Ignition": {


### PR DESCRIPTION
The recent version of the Kando pie menu added a feature for listing installed applications and icon themes. For this, the two read-only permissions are required.