### PR TITLE
Add exception for chat.simplex.simplex

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4799,6 +4799,9 @@
     "chat.iamb.iamb": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "chat.simplex.simplex": {
+        "finish-args-home-filesystem-access": "Allows the users to send/save files from/to their home directory"
+    },
     "cn.apipost.apipost": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },


### PR DESCRIPTION
Due to framework limitations of Java/Compose Multiplatform, SimpleX Chat cannot currently utilize the XDG Desktop Portal API.