### PR TITLE
fix: Add finish-args-unnecessary-xdg-config-gtk-3.0-ro-access exception for firedragon

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5859,7 +5859,8 @@
     },
     "org.garudalinux.firedragon": {
         "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.mozilla.firedragon": "Predates the linter rule"
+        "finish-args-own-name-wildcard-org.mozilla.firedragon": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "Needed for Breeze, etc. to use their colour scheme - upstream Firefox permission"
     },
     "org.kde.angelfish": {
         "finish-args-desktopfile-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Required for: https://github.com/flathub/org.garudalinux.firedragon/pull/90