### PR TITLE
Add exception for io.github.d0ksan8.zen-app-manager

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6200,6 +6200,5 @@
     },
     "com.bilingify.readest": {
         "finish-args-own-name-org.com_bilingify_readest.SingleInstance": "Required because Tauri hard-codes DBus service names and replaces dots with underscores"
-
     }
 }


### PR DESCRIPTION
Required for flathub/flathub#7229. This app is a Startup Manager and needs direct access to autostart directories.