### PR TITLE
Add `finish-args-contains-both-x11-and-wayland` exception for DiscordCanary

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2034,7 +2034,8 @@
         "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
     },
     "com.discordapp.DiscordCanary": {
-        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients are forced to update"
+        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients are forced to update",
+        "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
     },
     "com.hunterwittenborn.Celeste": {
         "finish-args-own-name-wildcard-org.kde": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation",


### PR DESCRIPTION
I'm [syncing DiscordCanary with Discord](https://github.com/flathub/com.discordapp.DiscordCanary/pull/730), and Discord still cannot work with fallback-x11 (see https://github.com/flathub-infra/flatpak-builder-lint/pull/580)