### PR TITLE
Add io.sourceforge.xtrkcad_fork.xtrkcad exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6193,6 +6193,9 @@
         "finish-args-flatpak-spawn-access": "the app is a launcher for other arbitrary applications configured by the user and requires the ability to spawn external processes on the host",
         "finish-args-home-filesystem-access": "many users place/install games and portable emulators/applications that Retrom must manage in arbitrary locations in the home directory"
     },
+    "io.sourceforge.xtrkcad_fork.xtrkcad": {
+        "finish-args-home-filesystem-access": "Needed since the app reads/writes track plans stored anywhere on users home directory"
+    },
     "com.teamspeak.Teakspeak": {
         "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Teamspeak will crash when audio or hotkey settings are opened"
     },


### PR DESCRIPTION
The xtrkcad app needs home directory access for reading/writing user track plans that could be stored anywhere on home directory.

Builds currently fail for pending PR: [pull#7255](https://github.com/flathub/flathub/pull/7255) without this exception.