### PR TITLE
Add exceptions for io.github.nikelaz.CTLDash

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,6 +1,6 @@
 {
     "io.github.nikelaz.CTLDash": {
-        "finish-args-systemd1-talk-name": "Needed to list, and control (start, top, restart, enable, disable) systemd user services.",
+        "finish-args-systemd1-talk-name": "Needed to list, and control (start, stop, restart, enable, disable) systemd user services.",
         "finish-args-systemd1-system-talk-name": "Needed to list and control (start, stop, restart, enable, disable) systemd system services.",
         "finish-args-flatpak-spawn-access": "Needed to execute host commands (systemctl enable/disable via pkexec, and journalctl for service logs), as these operations require escaping the sandbox to interact with the host's systemd."
     },


### PR DESCRIPTION
This is related to my [CTLDash app submission to Flathub](https://github.com/flathub/flathub/pull/7316).

The exceptions are described and are necessary as this is a systemd management application and does need some permissions to manage the user and system services.