### PR TITLE
Add exceptions for io.gitlab.Sanjai_Shaarugesh.Markforge

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6198,5 +6198,10 @@
     },
     "io.github.alamahant.BinauralPlayer": {
         "appid-url-not-reachable": "GitHub is being wonky atm"
+    },
+    "io.gitlab.Sanjai_Shaarugesh.Markforge": {
+      "finish-args-home-filesystem-access": "Markforge is a Markdown editor that requires home filesystem access to allow users to open, edit, and save documents from anywhere in their home directory. Users expect to work with files across their entire filesystem, not just specific directories like Documents or Downloads.",
+      "finish-args-arbitrary-dbus-access": "Markforge requires access to org.freedesktop.FileManager1 for file manager integration and org.gtk.vfs.* for GVFS support (network shares, remote locations).",
+      "finish-args-network-access": "Markforge requires network access to load external libraries (MathJax for LaTeX rendering and Mermaid for diagram rendering) from CDN servers. These libraries are essential for the live preview feature to properly render mathematical equations and diagrams in Markdown documents."
     }
 }


### PR DESCRIPTION
**App:** Markforge - A Markdown editor with live preview, LaTeX math, and Mermaid diagrams  
**Repository:** https://gitlab.com/Sanjai-Shaarugesh/Markforge

## Exceptions Requested

### 1. `finish-args-home-filesystem-access`
Markforge needs to open/save Markdown files anywhere in the user's home directory (project folders, git repos, documentation directories). Restricting to only `xdg-documents` or `xdg-download` would break typical workflows where users organize files in custom locations.

### 2. `finish-args-arbitrary-dbus-access`
Requires two specific D-Bus services (not full session-bus):
- `org.freedesktop.FileManager1` - "Show in File Manager" integration
- `org.gtk.vfs.*` - Access network shares, remote locations, and cloud storage via GVFS

### 3. `finish-args-network-access`
Loads MathJax and Mermaid libraries from CDN for rendering LaTeX equations and diagrams in live preview. Bundling isn't practical due to size (several MB each) and frequent updates.