### PR TITLE
Update exceptions to include optional wayland support for Yandex Browser

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3741,7 +3741,8 @@
     "ru.yandex.Browser": {
         "finish-args-dconf-talk-name": "Predates the linter rule",
         "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Optional wayland support"
     },
     "io.github.vikdevelop.SaveDesktop": {
         "finish-args-dconf-talk-name": "Predates the linter rule",


### PR DESCRIPTION
We want to give users ability to use both X11 and wayland mode. X11 by default and wayland by using command line flag.
This is the same configuration as in other chromium based browsers.