### PR TITLE
Add exception for org.kde.kjournaldbrowser

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1568,6 +1568,9 @@
         "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.kde.kjournaldbrowser": {
+        "finish-args-host-var-access": "required for read access to system journal log database"
+    },
     "org.kde.konsole": {
         "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"


### PR DESCRIPTION
kjournaldbrowser is a log viewer primarily for the system's journal log at /var/log/journal , thus access to that location is needed.

The manifest file is available here: https://invent.kde.org/system/kjournald/-/blob/master/.flatpak-manifest.yaml