### PR TITLE
exceptions: Drop org.kde.kopete (EOL'ed)

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2327,9 +2327,6 @@
     "org.kde.amarok": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "org.kde.kopete": {
-        "appstream-missing-developer-name": "grandfathered due to unannounced linter changes"
-    },
     "org.kde.skanlite": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },


### PR DESCRIPTION
See: https://github.com/flathub/org.kde.kopete/issues/145