### PR TITLE
Add exception for com.evepreview.manager

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6278,5 +6278,8 @@
     },
     "org.kde.picmi": {
         "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "com.evepreview.manager": {
+        "finish-args-own-name-wildcard-org.kde": "Needed for tray icon support with rust crate ksni"
     }
 }


### PR DESCRIPTION
Hello, I have a current pending PR for submitting com.evepreview.manager.
https://github.com/flathub/flathub/pull/7337

I am requesting an exception for the `finish-args-own-name-wildcard-org.kde` lint error. This is needed for its tray icon to work.

Thank you.