### PR TITLE
Add xdg config cosmic read-only access exception for CTL dash

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2,7 +2,8 @@
     "io.github.nikelaz.CTLDash": {
         "finish-args-systemd1-talk-name": "Needed to list, and control (start, stop, restart, enable, disable) systemd user services.",
         "finish-args-systemd1-system-talk-name": "Needed to list and control (start, stop, restart, enable, disable) systemd system services.",
-        "finish-args-flatpak-spawn-access": "Needed to execute host commands (systemctl enable/disable via pkexec, and journalctl for service logs), as these operations require escaping the sandbox to interact with the host's systemd."
+        "finish-args-flatpak-spawn-access": "Needed to execute host commands (systemctl enable/disable via pkexec, and journalctl for service logs), as these operations require escaping the sandbox to interact with the host's systemd.",
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
     },
     "org.vassalengine.vassal": {
         "finish-args-home-filesystem-access": "Needed to browse external game module files and saved games folders"


### PR DESCRIPTION
CTL Dash needs an exception to read xdg-config/cosmic:ro
Without that, it can't read preferences like theme/accent color or any changes in the preferences.
Read-only access seems to be the only way to fix that currently, based on what the other cosmic apps on flathub are using.