### PR TITLE
Add linter exception for io.gitlab.zulfian1732.jollpi-text-editor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "io.gitlab.zulfian1732.jollpi-text-editor": {
+        "finish-args-host-filesystem-access": "The app is a text editor intended to open and edit arbitrary files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations, similar to other text editors."
+    },
     "io.github.nikelaz.CTLDash": {
         "finish-args-systemd1-talk-name": "Needed to list, and control (start, stop, restart, enable, disable) systemd user services.",
         "finish-args-systemd1-system-talk-name": "Needed to list and control (start, stop, restart, enable, disable) systemd system services.",


### PR DESCRIPTION
This adds a linter exception for `finish-args-host-filesystem-access`.
Jollpi is a general-purpose text editor intended to open and edit arbitrary files chosen by the user. Full filesystem access is required for this functionality.