### PR TITLE
Add finish-args exceptions for org.pvermeer.WebAppHub

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6258,5 +6258,12 @@
     "io.github.epasveer.seer": {
         "finish-args-flatpak-spawn-access": "Seer needs to launch the gdb binary that is on the host system.",
         "finish-args-host-filesystem-access": "Seer needs to access the executable being debugged on the host system. Plus source files."
+    },
+    "org.pvermeer.WebAppHub": {
+        "finish-args-flatpak-system-folder-access": "Used to fetch the icons of system installed flatpak browsers.",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Used to fetch the icons of user installed flatpak browsers.",
+        "finish-args-flatpak-spawn-access": "This is needed to fetch installed browser information and to run the created Web App from this application.",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Used to create and delete owned desktop files for web apps.",
+        "finish-args-flatpak-appdata-folder-access": "Used to create isolated profile folder for flatpak browsers. For some flatpak browsers it's necessary to create a directory in their sandbox for profile isolation. For some browsers it's used to update the isolated profile config for a minimal ui."
     }
 }


### PR DESCRIPTION
This adds a linter exceptions for org.pvermeer.WebAppHub as discussed in https://github.com/flathub/flathub/pull/7328#discussion_r2622812406 for new submission in flathub/flathub#7328.

I've tried to narrow permissions as must as possible.