### PR TITLE
Add new exception for goverlay introduced with 1.6.7 update

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5042,7 +5042,8 @@
     },
     "io.github.benjamimgois.goverlay": {
         "finish-args-unnecessary-xdg-config-MangoHud-rw-access": "Needed for reading MangoHud config files",
-        "finish-args-unnecessary-xdg-config-vkBasalt-rw-access": "Needed for reading vkBasalt config files"
+        "finish-args-unnecessary-xdg-config-vkBasalt-rw-access": "Needed for reading vkBasalt config files",
+        "finish-args-flatpak-appdata-folder-access": "Needed for reading Steam and other applications’ MangoHud configuration"
     },
     "io.github.bothlab.pomidaq": {
         "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
I'll update the manifest to 1.6.7 shortly

Edit: I've updated the manifest