### PR TITLE
Add exception for io.github.totoshko88.RustConn

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,106 +1,581 @@
 {
-    "io.gitlab.zulfian1732.jollpi-text-editor": {
-        "finish-args-host-filesystem-access": "The app is a text editor intended to open and edit arbitrary files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations, similar to other text editors."
+    "app.authpass.AuthPass": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.nikelaz.CTLDash": {
-        "finish-args-systemd1-talk-name": "Needed to list, and control (start, stop, restart, enable, disable) systemd user services.",
-        "finish-args-systemd1-system-talk-name": "Needed to list and control (start, stop, restart, enable, disable) systemd system services.",
-        "finish-args-flatpak-spawn-access": "Needed to execute host commands (systemctl enable/disable via pkexec, and journalctl for service logs), as these operations require escaping the sandbox to interact with the host's systemd.",
-        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+    "app.bluebubbles.BlueBubbles": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "org.vassalengine.vassal": {
-        "finish-args-home-filesystem-access": "Needed to browse external game module files and saved games folders"
+    "app.cantara.Cantara": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "app.devsuite.Manuals": {
+        "finish-args-flatpak-spawn-access": "application uses libflatpak to install SDK documentation",
+        "finish-args-flatpak-system-talk-name": "application uses libflatpak install SDK documentation",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-gtk-doc-ro-access": "Manuals requires access to locally installed documentation",
+        "finish-args-unnecessary-xdg-data-doc-ro-access": "Manuals requires access to locally installed documentation",
+        "finish-args-unnecessary-xdg-data-devhelp-ro-access": "Manuals requires access to locally installed documentation"
+    },
+    "app.devsuite.Ptyxis": {
+        "finish-args-flatpak-spawn-access": "application requires ptyxis-agent for PTY setup on host",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "app.drey.KeyRack": {
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "the app predates this linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule"
+    },
+    "app.drey.Warp": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "app.freelens.Freelens": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "app.getclipboard.Clipboard": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "app.katvan.Katvan": {
+        "finish-args-unnecessary-xdg-data-typst-ro-access": "Well known common location of the user's Typst packages in the @local namespace"
+    },
+    "app.lith.Lith": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "app.logorrr.LogoRRR": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "app.midterm.MidtermDesktop": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "app.opencomic.OpenComic": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "app.organicmaps.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule"
+    },
+    "app.pianocheetah.pianocheetah": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "app.rednotebook.RedNotebook": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "app.riftshare.RiftShare": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "app.twintaillauncher.ttl": {
         "finish-args-desktopfile-filesystem-access": "Application can create .desktop file shortcuts for games... literally can not write those files without access to the folder",
         "finish-args-flatpak-appdata-folder-access": "Application can write Steam shortcuts to its shortcuts.vdf file and it needs this to access flatpak Steam"
     },
-    "page.codeberg.cozyowl.OpaqueFiles": {
-        "finish-args-host-filesystem-access": "Needed to encrypt, decrypt or check files in HOME and on mounted filesystems (USB, Network, ...)"
-    },
-    "io.github.N3kosempai.klia-store": {
-        "finish-args-flatpak-spawn-access": "Klia Store is a Flatpak application manager that needs to execute flatpak commands on the host system using flatpak-spawn to install, update, and manage other Flatpak applications.",
-        "finish-args-flatpak-system-talk-name": "Required to communicate with the Flatpak system service (org.freedesktop.Flatpak) to manage both user and system-level Flatpak installations.",
-        "finish-args-flatpak-system-folder-access": "Read-only access to /var/lib/flatpak is required to list and display information about system-installed Flatpak applications.",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Read-only access to XDG_DATA_HOME/flatpak is required to list and display information about user-installed Flatpak applications.",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "Read-only access to XDG_DATA_HOME/applications is required to display desktop entries and application metadata for installed Flatpak applications."
-    },
-    "io.github.mfat.sshpilot": {
-        "finish-args-has-socket-ssh-auth": "Needs host SSH agent for seamless key-based SSH; app implements secure retrieval of secrets from keychain and adding them to ssh-agent for use.",
-        "finish-args-ssh-filesystem-access": "Just read-only access to load user's existing keypairs.",
-        "finish-args-flatpak-spawn-access": "The app is basically a terminal emulator with extra options for SSH. Users expect host shell access weh opening a local terminal tab."
-    },
-    "io.github.BuddySirJava.SSH-Studio": {
-        "finish-args-ssh-filesystem-access": "This app's main functionality is to edit ssh connections located in ~/.ssh/config",
-        "finish-args-has-socket-ssh-auth": "Needed for testing ssh connections (Located in HostEditor)"
-    },
-    "io.github.swordpuffin.rewaita": {
-        "finish-args-autostart-filesystem-access": "Needed for manually creating an autostart file with specific parameters which cannot be done through Libportal"
-    },
-    "io.github.kolunmi.Bazaar": {
-        "finish-args-flatpak-spawn-access": "Runs host binaries in order to successfully install and launch apps",
-        "finish-args-flatpak-system-folder-access": "Needs access to system-wide flatpak installation so that it can manage them",
-        "finish-args-flatpak-system-talk-name": "Talks to the system-wide flatpak dbus address in order to query existence of flatpaks and send installation commands to it",
-        "finish-args-flatpak-appdata-folder-access": "Needs access to user data of other apps so that it can remove leftover data"
-    },
-    "com.ml4w.dotfilesinstaller": {
-        "finish-args-home-filesystem-access": "As the app is a dotfiles management tool, access to the home directory is required for the application's core functionality."
-    },
-    "io.github.fastrizwaan.WineCharm": {
-        "finish-args-flatpak-appdata-folder-access": "Access the data directories of WineZGUI (same author) rw for to list WineZGUI scripts in WineCharm, and read-only access for wine, bottles, playonlinux, Phoenicis,  for copying runners and prefixes if/when user requires.",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.rfrench3.scopebuddy-gui": {
-        "finish-args-unnecessary-xdg-config-scopebuddy-create-access": "This program needs to be able to create and modify xdg-config/scopebuddy/scb.conf (edit config of host Scopebuddy)"
-    },
-    "io.github.sockeye_d.godl": {
-        "finish-args-host-filesystem-access": "needed to access and modify projects outside of sandbox"
-    },
-    "io.github.swordpuffin.wardrobe": {
-        "finish-args-dconf-talk-name": "needed to access host dconf configuration",
+    "app.vup.Vup": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.TeamWheelWizard.WheelWizard": {
-        "finish-args-unnecessary-xdg-config-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin config files (e.g. for graphics settings)",
-        "finish-args-unnecessary-xdg-data-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin Mii and game/mod data files",
-        "finish-args-flatpak-appdata-folder-access": "this program needs to be able to access the Dolphin Flatpak's config and data directories for configuration and Mii/mod management",
-        "finish-args-flatpak-spawn-access": "this program needs to be able to run host commands as specified in the manifest's wrapper scripts to support Flatpak and native Dolphin installations"
+    "app.xemu.xemu": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
-    "io.github.mhogomchungu.sirikali": {
-        "finish-args-flatpak-spawn-access": "this app is a front end to gocryptfs,securefs and cryfs. These tools do folder based encryption and they depend on fusermount located at /bin to mount and unmount their file systems"
+    "app.zen_browser.zen": {
+        "finish-args-own-name-wildcard-org.mozilla.zen": "Predates the linter rule"
     },
-    "org.flathub.exceptions": {
-        "appid-filename-mismatch": "required as I like pies",
-        "toplevel-no-command": "another nonsensical reason",
-        "flathub-json-deprecated-i386-arch-included": "this would be a warning but is also skipped"
+    "ar.com.pilas_engine.App": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "org.flathub.exceptions_wildcard": {
-        "*": "ignore all errors and warnings"
+    "ar.com.softwareperonista.Rockarrolla": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
-    "page.codeberg.dnkl.foot": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via host-spawn",
-        "finish-args-only-wayland": "this program doesn't have x11 support"
+    "ar.com.tuxguitar.TuxGuitar": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "page.codeberg.libre_menu_editor.LibreMenuEditor": {
-        "finish-args-unnecessary-xdg-data-xdg-desktop-portal-ro-access": "for reading .desktop files and icons in xdg-data/xdg-desktop-portal",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "for reading .desktop files and symlink targets in xdg-data/flatpak",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "for creating, reading, modifying, and deleting .desktop files in xdg-data/applications",
-        "finish-args-unnecessary-xdg-config-mimeapps.list-create-access": "for reading and updating mimetypes in xdg-config/mimeapps.list",
-        "finish-args-flatpak-spawn-access": "for reading environment variables on the host system",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
+    "ar.xjuan.Cambalache": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "art.taunoerik.tauno-monitor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "at.priv.toastfreeware.ConfClerk": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "au.edu.uq.esys.escript": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "best.ellie.StartupConfiguration": {
+        "finish-args-unnecessary-xdg-config-autostart-create-access": "This app requires access to the hosts' ~/.config/autostart directory in create mode in order to manage applications launched on startup.",
+        "finish-args-flatpak-system-folder-access": "This app requires read-only access to the hosts' /var/lib/flatpak/exports/share/{applications,icons} directories in order to allow users to add them to the applications launched on startup.",
+        "finish-args-flatpak-user-folder-access": "This app requires read-only access to the hosts' ~/.local/share/flatpak/exports/share/{applications,icons} directories in order to allow users to add them to the applications launched on startup.",
+        "finish-args-host-var-access": "This app requires read-only access to the hosts' /var/lib/snapd/desktop/applications directory in order to allow users to add snaps to the applications launched on startup.",
+        "finish-args-autostart-filesystem-access": "Predates the linter rule",
         "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
         "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "br.app.pw3270.terminal": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "br.com.wiselabs.simplexity": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "br.eng.silas.qpdftools": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "br.gov.cti.invesalius": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "ca._0ldsk00l.Nestopia": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "ca.desrt.dconf-editor": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "ca.edestcroix.Recordbox": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "ca.littlesvr.asunder": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "ca.parallel_launcher.ParallelLauncher": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-talk-name": "Predates the linter rule"
+    },
+    "ca.uwaterloo.Raven": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "cat.xtec.clic.JClic": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "cc.arduino.IDE2": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "cc.arduino.arduinoide": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "cc.nift.nsm": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "cc.retroshare.retroshare-gui": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "ch.openboard.OpenBoard": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "ch.theologeek.Manuskript": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "ch.tlaun.TL": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "ch.x29a.playitslowly": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "chat.delta.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "chat.iamb.iamb": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "chat.quadrix.Quadrix": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "chat.rocket.RocketChat": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "chat.schildi.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "chat.simplex.simplex": {
+        "finish-args-home-filesystem-access": "Allows the users to send/save files from/to their home directory"
+    },
+    "cn.apipost.apipost": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "cn.navclub.ldbfx": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "cn.ottercorp.xivlaunchercn": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "codes.loers.Karlender": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "codes.merritt.Nyrna": {
+        "finish-args-flatpak-spawn-access": "required to access and change process status on the host"
+    },
+    "com.abagames.rRootage": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.abisource.AbiWord": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.adamcake.Bolt": {
+        "finish-args-unnecessary-xdg-data-icons-create-access": "individual games' window icons need to be downloaded and copied to xdg-data/icons as the user installs or updates them",
+        "finish-args-contains-both-x11-and-wayland": "some games support wayland and some don't"
+    },
+    "com.adilhanney.ricochlime": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.adilhanney.saber": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.adilhanney.super_nonogram": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.adobe.Flash-Player-Projector": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.albiononline.AlbionOnline": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.amazon.Workspaces": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.anydesk.Anydesk": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
     "com.apifox.Apifox": {
         "flathub-json-automerge-enabled": "Extra-data app with unversioned source link"
     },
+    "com.arviceblot.eso-addon-manager": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "com.atlauncher.ATLauncher": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.axosoft.GitKraken": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.bambulab.BambuStudio": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.beavernotes.beavernotes": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.gtk.vfs": "Predates the linter rule"
+    },
+    "com.behringer.XAirEdit": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.belmoussaoui.snowglobe": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.qemu": "Predates the linter rule"
+    },
+    "com.bespokesynth.BespokeSynth": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.bestaticpy.bestatic": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.bilingify.readest": {
+        "finish-args-own-name-org.com_bilingify_readest.SingleInstance": "Required because Tauri hard-codes DBus service names and replaces dots with underscores"
+    },
+    "com.binarynonsense.acbr": {
+        "finish-args-home-filesystem-access": "As a reader and converter of comic book files, with an integrated file explorer, access to the home directory is required for some of the application's core features."
+    },
+    "com.bishwasaha.Koncentro": {
+        "finish-args-flatpak-spawn-access": "the app needs to run commands to change proxy settings on the host",
+        "finish-args-unnecessary-xdg-config-environment.d-create-access": "the app needs to set proxy environment variables for terminal applications"
+    },
+    "com.bitwarden.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "com.bitwig.BitwigStudio": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.bixense.PasswordCalculator": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.bktus.gpgfrontend": {
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
+    },
+    "com.bladecoder.adventure-editor": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.blitterstudio.amiberry": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.borgbase.Vorta": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "com.brave.Browser": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Access host tmp for MPRIS media cover art",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.brosix.Brosix": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.calibre_ebook.calibre": {
+        "finish-args-unnecessary-xdg-data-Trash-rw-access": "Needs direct trash access, doesn't use portal",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.carpeludum.KegaFusion": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.cassidyjames.butler": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.cassidyjames.plausible": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.cburch.Logisim": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.cerebralnomad.recipescribe": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.chatterino.chatterino": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.chez.GrafX2": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.chowdsp.BYOD": {
+        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.BYOD": "Predates the linter rule"
+    },
+    "com.cinecred.cinecred": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.codemouse92.timecard": {
+        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.core447.StreamController": {
+        "finish-args-flatpak-spawn-access": "required to allow plugins to open apps on the host",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.corsixth.corsixth": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.darhon.syncbackup": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.dec05eba.gpu_screen_recorder": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn to capture a monitor on AMD/Intel GPUs",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.devolutions.remotedesktopmanager": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.diffingo.fwbackups": {
+        "finish-args-flatpak-spawn-access": "required to backup and restore installed packages",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "com.dingtalk.DingTalk": {
         "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"
     },
-    "com.github.sixpounder.GameOfLife": {
+    "com.discordapp.Discord": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
+    },
+    "com.discordapp.DiscordCanary": {
+        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients are forced to update",
+        "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
+    },
+    "com.diy_fever.DIYLayoutCreator": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.dosbox_x.DOSBox-X": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.doycho.euterpe.gtk": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.dropbox.Client": {
+        "finish-args-own-name-wildcard-org.kde": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.eduke32.EDuke32": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.endlessm.photos": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.expidusos.file_manager": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.fightcade.Fightcade": {
+        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function"
+    },
+    "com.flashforge.FlashPrint": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.frac_tion.teleport": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.francescogaglione.chronos": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "com.francescogaglione.cosmicmoney": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "com.freerdp.FreeRDP": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.georgefb.mangareader": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.georgefb.quickaccess": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.getmailspring.Mailspring": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.getpostman.Postman": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.giadamusic.Giada": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.gigitux.youp": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.gitbutler.gitbutler": {
+        "finish-args-has-socket-gpg-agent": "Needed to sign Git commits with GPG",
+        "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
+        "finish-args-host-filesystem-access": "Needed to access Git repositories outside the sandbox",
+        "finish-args-own-name-com.gitbutler.app": "Needed for D-Bus service registration"
+    },
+    "com.gitfiend.GitFiend": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.github.ADBeveridge.Raider": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.Alcaro.Flips": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.AlizaMedicalImaging.AlizaMS": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.AmatCoder.mednaffe": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.Anuken.Mindustry": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.Bleuzen.FFaudioConverter": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.Darazaki.Spedread": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.Eloston.UngoogledChromium": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "optional wayland support"
+    },
+    "com.github.Flacon": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.GradienceTeam.Gradience": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-flatpak-spawn-access": "required to change the gnome-shell theme via gsettings",
+        "finish-args-unnecessary-xdg-config-gtk-4.0-rw-access": "Required to change gtk configuration on host",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "Required to change gtk configuration on host",
+        "finish-args-unnecessary-xdg-data-flatpak-create-access": "https://github.com/flathub/flathub/issues/3557"
+    },
+    "com.github.IsmaelMartinez.teams_for_linux": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.JannikHv.Gydl": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.github.Johnn3y.Forklift": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.KRTirtho.Spotube": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.LongSoft.UEFITool": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.Matoking.protontricks": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "com.github.Murmele.Gittyup": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.github.Murmele.scram": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.PintaProject.Pinta": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.PopoutApps.popout3d": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.Qv2ray": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Predates the linter rule"
+    },
+    "com.github.Rosalie241.RMG": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.Xenoveritas.abuse": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "com.github._0negal.Viper": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -110,9 +585,6 @@
     "com.github._4lex4.ScanTailor-Advanced": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.github.ADBeveridge.Raider": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.afrantzis.Bless": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -133,28 +605,12 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.github.Alcaro.Flips": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
     "com.github.alecaddd.sequeler": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-ssh-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
     "com.github.alexhuntley.Plots": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.AlizaMedicalImaging.AlizaMS": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.github.AmatCoder.mednaffe": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.github.Anuken.Mindustry": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.appadeia.Taigo": {
@@ -212,11 +668,6 @@
     "com.github.bjaraujo.Bombermaaan": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.github.Bleuzen.FFaudioConverter": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "com.github.bluesabre.darkbar": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -278,9 +729,6 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.github.Darazaki.Spedread": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.github.dariasteam.cowsrevenge": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
@@ -304,20 +752,12 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
-    "io.github.dosbox-staging": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
     "com.github.dynobo.normcap": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-kwin-talk-name": "Predates the linter rule"
     },
     "com.github.edenalencar.identifications": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.Eloston.UngoogledChromium": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "optional wayland support"
     },
     "com.github.elth0r0.iqpuzzle": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -333,9 +773,6 @@
     "com.github.emmanueltouzery.projectpad": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "io.github.erkin.ponysay": {
-        "finish-args-not-defined": "Terminal only, predates the linter"
-    },
     "com.github.fabiocolacio.marker": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
@@ -343,11 +780,6 @@
     },
     "com.github.finefindus.eyedropper": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.Flacon": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.github.flxzt.rnote": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
@@ -385,13 +817,6 @@
     },
     "com.github.gpuvis.Gpuvis": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.GradienceTeam.Gradience": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-flatpak-spawn-access": "required to change the gnome-shell theme via gsettings",
-        "finish-args-unnecessary-xdg-config-gtk-4.0-rw-access": "Required to change gtk configuration on host",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "Required to change gtk configuration on host",
-        "finish-args-unnecessary-xdg-data-flatpak-create-access": "https://github.com/flathub/flathub/issues/3557"
     },
     "com.github.gyunaev.spivak": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -435,20 +860,12 @@
     "com.github.iortcw.iortcw": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "com.github.IsmaelMartinez.teams_for_linux": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
     "com.github.iwalton3.jellyfin-media-player": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
     "com.github.iwalton3.jellyfin-mpv-shim": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.JannikHv.Gydl": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "com.github.jeromerobert.pdfarranger": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -474,10 +891,6 @@
     },
     "com.github.johnfactotum.QuickLookup": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.Johnn3y.Forklift": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.github.joseexposito.touche": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -512,9 +925,6 @@
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.github.KRTirtho.Spotube": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.github.lachhebo.Gabtag": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -522,9 +932,6 @@
     "com.github.libresprite.LibreSprite": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.github.LongSoft.UEFITool": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.louis77.tuner": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
@@ -536,14 +943,14 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.github.maoschanz.drawing": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.github.maoschanz.DynamicWallpaperEditor": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.maoschanz.drawing": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.marhkb.Pods": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -558,11 +965,6 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-host-tmp-access": "Predates the linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.github.Matoking.protontricks": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
     },
     "com.github.mgropp.PdfJumbler": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -594,17 +996,6 @@
     },
     "com.github.muriloventuroso.pdftricks": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.Murmele.Gittyup": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.github.Murmele.scram": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.github.naaando.lyrics": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -653,15 +1044,8 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.github.PintaProject.Pinta": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.github.polymeilex.neothesia": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.github.PopoutApps.popout3d": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.github.powertab.powertabeditor": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
@@ -679,11 +1063,6 @@
         "appid-code-hosting-too-few-components": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.github.Qv2ray": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Predates the linter rule"
     },
     "com.github.rafostar.Clapper": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
@@ -719,9 +1098,6 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.github.Rosalie241.RMG": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.github.ryanakca.slingshot": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
@@ -748,6 +1124,9 @@
     "com.github.shonumi.gbe-plus": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.github.sixpounder.GameOfLife": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.skullernet.q2pro": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
@@ -799,13 +1178,13 @@
     "com.github.treagod.spectator": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "com.github.unrud.djpdf": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.github.unrud.RemoteTouchpad": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.unrud.VideoDownloader": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "com.github.unrud.djpdf": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.utsushi.Utsushi": {
@@ -844,10 +1223,6 @@
     "com.github.wwmm.pulseeffects.plugin.lsp-plugins": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "com.github.Xenoveritas.abuse": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
     "com.github.xournalpp.xournalpp": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
@@ -855,12 +1230,12 @@
     "com.github.yucefsourani.albasheer-electronic-quran-browser": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
+    "com.github.z.Cumulonimbus": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
     "com.github.zadam.trilium": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.github.z.Cumulonimbus": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.github.zocker_160.SyncThingy": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -872,52 +1247,12 @@
         "finish-args-host-var-access": "Predates the linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
-    "app.organicmaps.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule"
+    "com.gitlab.ColinDuquesnoy.MellowPlayer": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "chat.delta.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "chat.schildi.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.bitwarden.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.irccloud.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule"
-    },
-    "com.jetpackduba.Gitnuro": {
-        "finish-args-flatpak-spawn-access": "required to access external terminal emulators and run external credentials managers for Git",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.jgraph.drawio.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+    "com.gitlab.Murmele.UDPLogger": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.bluesabre.MenuLibre": {
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "MenuLibre manages desktop file entries. It needs to create desktop files in xdg-data/applications",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "MenuLibre manages desktop file entries. It needs to create desktop files in xdg-data/applications",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.kiwix.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.telegram.desktop": {
-        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "external-gitmodule-url-found": "Predates the linter rule",
-        "module-tg_owt-checker-tracks-commits": "Manually updated, grandfathered",
-        "module-tde2e-checker-tracks-commits": "Manually updated"
     },
     "com.gitlab.adnan338.Invoicer": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
@@ -932,15 +1267,12 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
-    "com.gitlab.ColinDuquesnoy.MellowPlayer": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "com.gitlab.coringao.cavestory-nx": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
     "com.gitlab.coringao.JAG": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.gitlab.coringao.cavestory-nx": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.gitlab.cutecom.cutecom": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
@@ -968,122 +1300,29 @@
     "com.gitlab.maevemi.publictransport": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "com.gitlab.Murmele.UDPLogger": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.gitlab.Turtlico": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
     "com.gitlab.tipp10.tipp10": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
-    "org.catacombing.kumo": {
-        "finish-args-only-wayland": "this program doesn't have x11 support"
-    },
-    "org.codeberg.dimkard.glossaico": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
-    },
-    "io.qt.qdbusviewer": {
-        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access"
-    },
-    "org.syntalos.syntalos": {
-        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Contacts": {
-        "finish-args-unnecessary-xdg-data-pixmaps-create-access": "the app predates this linter rule",
-        "finish-args-unnecessary-xdg-cache-evolution-ro-access": "the app predates this linter rule, used for evolution data server",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.dspy": {
-        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access"
-    },
-    "org.freedesktop.Bustle": {
-        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access"
-    },
-    "org.gnome.Builder": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "app.devsuite.Manuals": {
-        "finish-args-flatpak-spawn-access": "application uses libflatpak to install SDK documentation",
-        "finish-args-flatpak-system-talk-name": "application uses libflatpak install SDK documentation",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-data-gtk-doc-ro-access": "Manuals requires access to locally installed documentation",
-        "finish-args-unnecessary-xdg-data-doc-ro-access": "Manuals requires access to locally installed documentation",
-        "finish-args-unnecessary-xdg-data-devhelp-ro-access": "Manuals requires access to locally installed documentation"
-    },
-    "app.devsuite.Ptyxis": {
-        "finish-args-flatpak-spawn-access": "application requires ptyxis-agent for PTY setup on host",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Totem.Devel": {
-        "module-totem-source-git-no-tag-commit-branch": "This is the development version of Totem, tracking upstream",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "manifest-file-is-symlink": "Predates the linter rule"
-    },
-    "org.gimp.GIMP": {
-        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "gtk-3.0 and GIMP config.",
-        "finish-args-unnecessary-xdg-config-GIMP-create-access": "GIMP config always used",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gitfourchette.gitfourchette": {
-        "finish-args-flatpak-spawn-access": "Start external merge tool via flatpak-spawn",
-        "finish-args-has-socket-ssh-auth": "Authenticate with git remotes via host's ssh-agent",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.fcitx.Fcitx5": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
-        "finish-args-unnecessary-xdg-config-fcitx-create-access": "need for simulating ibus daemon and changing kde system xkb settings",
-        "finish-args-unnecessary-xdg-config-kxkbrc-rw-access": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-cache-ibus-create-access": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-config-ibus-create-access": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Input method daemon need to talk with both XWayland/X11/Wayland applications at the same time"
-    },
-    "com.jetbrains.PyCharm-Professional": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.jetbrains.Rider": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.libreoffice.LibreOffice": {
-        "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/111> 'GTK bookmarks do not appear in the flatpak version of LibreOffice'",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/136> 'fontconfig user configuration'",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.libreoffice.LibreOfficeIpc0": "Predates the linter rule"
-    },
-    "com.st.STM32CubeIDE": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+    "com.gluonhq.SceneBuilder": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "org.codeblocks.codeblocks": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+    "com.google.AndroidStudio": {
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
-    "org.eclipse.Java": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    "com.google.Chrome": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule"
+    },
+    "com.google.ChromeDev": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule"
+    },
+    "com.gopeed.Gopeed": {
+        "finish-args-own-name-com.gopeed.gopeed": "Predates the linter rule"
     },
     "com.hack_computer.Clubhouse": {
         "finish-args-arbitrary-dbus-access": "https://github.com/flathub/flathub/pull/1873/files#r500116002",
@@ -1099,59 +1338,70 @@
         "finish-args-own-name-com.hack_computer.HackSoundServer": "Predates the linter rule",
         "finish-args-own-name-com.hack_computer.HackToolbox": "Predates the linter rule"
     },
-    "com.bishwasaha.Koncentro": {
-        "finish-args-flatpak-spawn-access": "the app needs to run commands to change proxy settings on the host",
-        "finish-args-unnecessary-xdg-config-environment.d-create-access": "the app needs to set proxy environment variables for terminal applications"
-    },
-    "ca.desrt.dconf-editor": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "page.tesk.Refine": {
-        "finish-args-flatpak-spawn-access": "needed to access host dconf configuration",
-        "finish-args-unnecessary-xdg-config-dconf-rw-access": "needed to access host dconf configuration at launch time",
-        "finish-args-direct-dconf-path": "needed to access host dconf configuration",
-        "finish-args-dconf-talk-name": "needed to access host dconf configuration"
-    },
-    "org.altlinux.Tuner": {
-        "finish-args-unnecessary-xdg-config-dconf-rw-access": "needed to access host dconf configuration at launch time",
-        "finish-args-direct-dconf-path": "needed to access host dconf configuration",
-        "finish-args-dconf-talk-name": "needed to access host dconf configuration"
-    },
-    "cc.nift.nsm": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.axosoft.GitKraken": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.borgbase.Vorta": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.chatterino.chatterino": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+    "com.hack_computer.OperatingSystemApp": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
-    "com.georgefb.quickaccess": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+    "com.hack_computer.Sidetrack": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.haysell.pos": {
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "com.getmailspring.Mailspring": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    "com.helix_editor.Helix": {
+        "finish-args-flatpak-spawn-access": "required to access language servers installed on host",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "com.google.AndroidStudio": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    "com.heroicgameslauncher.hgl": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-umu-create-access": "Uses shared installation for the umu runtime",
+        "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Access shared MangoHud configuration files",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.hoptodesk.HopToDesk": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.hostbuf.FinalShell": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.humatarayici.od": {
+        "finish-args-own-name-wildcard-org.mozilla.huma": "Predates the linter rule"
+    },
+    "com.icanblink.blink": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.icons8.Lunacy": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.inform7.IDE": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.inklestudios.Inky": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.inochi2d.inochi-creator": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.interversehq.qView": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.irccloud.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule"
+    },
+    "com.itextpdf.RUPS": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.itopia.client": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.jagex.RuneScape": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.jaquadro.NBTExplorer": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.jetbrains.CLion": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
@@ -1163,6 +1413,11 @@
     "com.jetbrains.DataGrip": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "external-gitmodule-url-found": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.jetbrains.GoLand": {
         "finish-args-host-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-gpg-agent": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
@@ -1184,8 +1439,67 @@
         "finish-args-has-socket-gpg-agent": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
+    "com.jetbrains.PyCharm-Professional": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.jetbrains.Rider": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.jetbrains.RustRover": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "com.jetbrains.WebStorm": {
         "finish-args-home-filesystem-access": "Needed to browse project files"
+    },
+    "com.jetpackduba.Gitnuro": {
+        "finish-args-flatpak-spawn-access": "required to access external terminal emulators and run external credentials managers for Git",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.jgraph.drawio.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.jianguoyun.Nutstore": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.jpexs.decompiler.flash": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.jwestall.Forecast": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read the system theme and listen for config changes in the host"
+    },
+    "com.katawa_shoujo.KatawaShoujo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.kavilgroup.gelectrical": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.kavilgroup.gestimator": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.kgurgul.cpuinfo": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.konstantintutsch.Lock": {
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
+    },
+    "com.kristianduske.TrenchBroom": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.ktechpit.orion": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "com.lablicate.OpenChrom": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
     },
     "com.leinardi.gst": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
@@ -1195,9 +1509,167 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
+    "com.librumreader.librum": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.logseq.Logseq": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.lunarclient.LunarClient": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.lynnmichaelmartin.TimeTracker": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.mastermindzh.tidal-hifi": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.mattermost.Desktop": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.mattjakeman.ExtensionManager": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.microsoft.AzureStorageExplorer": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "com.microsoft.Edge": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.microsoft.EdgeDev": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.mikrotik.WinBox": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.milesalan.mepo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.ml4w.dotfilesinstaller": {
+        "finish-args-home-filesystem-access": "As the app is a dotfiles management tool, access to the home directory is required for the application's core functionality."
+    },
+    "com.modrinth.ModrinthApp": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.mongodb.Compass": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.mousepawmedia.omission": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule"
+    },
+    "com.mtkennerly.madamiru": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.neatdecisions.Detwinner": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.neoutils.NeoRegex": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.nextcloud.desktopclient.nextcloud": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-com.nextcloudgmbh.Nextcloud": "Predates the linter rule"
+    },
+    "com.nickgirga.webready": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.nitrokey.nitrokey-app": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.nolimitconnect.NoLimitConnect": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.nomachine.nxplayer": {
+        "finish-args-ssh-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "com.notepadqq.Notepadqq": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.ntrack.n-track": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.ReserveDevice1": "Predates the linter rule"
+    },
+    "com.obsproject.Studio": {
+        "finish-args-flatpak-spawn-access": "Required for the virtual camera feature",
+        "external-gitmodule-url-found": "Flatpak are published by upstream from their own repo",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.okta.developer.CLI": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.one_ware.OneWare": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.openwall.John": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.opera.Opera": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.orama_interactive.Pixelorama": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.outerwildsmods.owmods_gui": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "com.oyajun.ColorCode": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.ozmartians.VidCutter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.parallax.PropellerIDE": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.pinegrow.Pinegrow": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.pixelomer.ShijimaQt": {
+        "finish-args-kwin-talk-name": "Predates the linter rule"
+    },
+    "com.playonlinux.PlayOnLinux4": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.pojtinger.felicitas.Multiplex": {
+        "finish-args-flatpak-spawn-access": "Needed to execute external copies of MPV and control them via IPC",
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "com.polyphone_soundfonts.polyphone": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.popcornfx.PopcornFXEditor": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.pot_app.pot": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.poweriso.PowerISO": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.protonvpn.www": {
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule",
+        "finish-args-own-name-proton.vpn.app.gtk": "Predates the linter rule"
     },
     "com.prusa3d.PrusaSlicer": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
@@ -1205,6 +1677,15 @@
         "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-own-name-wildcard-com.prusa3d.prusaslicer": "Predates the linter rule"
+    },
+    "com.pypyrev.linuxdcpp": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.qq.QQ": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "com.quexten.Goldwarden": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
     },
     "com.raggesilver.BlackBox": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
@@ -1218,13 +1699,182 @@
         "finish-args-host-tmp-access": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "com.realm667.Wolfenstein_Blade_of_Agony": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.redis.RedisInsight": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.reqable.Reqable": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.retrodev.blastem": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.revolutionarygamesstudio.ThriveLauncher": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.richwhitehouse.BigPEmu": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.rioterm.Rio": {
+        "finish-args-flatpak-spawn-access": "required to spawn the user's shell and other commands on the host system; it's the primary purpose of a terminal emulator"
+    },
+    "com.rosegardenmusic.rosegarden": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.rtosta.zapzap": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.rustdesk.RustDesk": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.sayonara_player.Sayonara": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.scanoss.sbom-workbench": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.sciactive.QuickDAV": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.shatteredpixel.shatteredpixeldungeon": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.sigil_ebook.Sigil": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.sigmyne.crush": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.simulide.simulide": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.sireliah.Dragit": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.skype.Client": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.slack.Slack": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "com.sleepfiles.OSCAR": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.slugchess.SlugChess": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.snes9x.Snes9x": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.sourcepole.kadas": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.st.STM32CubeIDE": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.st.STM32CubeMX": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.steamdeckrepo.manager": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.steamgriddb.SGDBoop": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Read-only access to /var/lib/flatpak/app/com.valvesoftware.Steam to check whether Steam Flatpak is installed"
+    },
+    "com.steamgriddb.steam-rom-manager": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.stremio.Stremio": {
+        "finish-args-contains-both-x11-and-wayland": "The window is able to be create under wayland but this app uses CEF (Chromium Embedded Framework) which requires acccess to X11"
+    },
+    "com.strlen.TreeSheets": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.sublimemerge.App": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+        "finish-args-own-name-com.sublimemerge": "Predates the linter rule"
+    },
+    "com.sublimetext.three": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.super_productivity.SuperProductivity": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.supermodel3.Supermodel": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.sweethome3d.Sweethome3d": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.sweetscape.ZeroOneZeroEditor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.synology.CloudStationBackup": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.synology.SynologyDrive": {
+        "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.syntevo.SmartGit": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "com.syntevo.SmartSynchronize": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "com.ulduzsoft.Birdtray": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    "com.teamspeak.TeamSpeak": {
+        "finish-args-unnecessary-xdg-config-TeamSpeak-rw-access": "TeamSpeak 6 plugins installation directory.",
+        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Teamspeak will crash when audio or hotkey settings are opened"
+    },
+    "com.teeworlds.Teeworlds": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "com.tencent.WeChat": {
+        "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"
+    },
+    "com.termius.Termius": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.thewavewarden.Odin2": {
+        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Odin2": "Predates the linter rule"
+    },
+    "com.thincast.client": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.tic80.TIC_80": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.ticktick.TickTick": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.tominlab.wonderpen": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "com.toolstack.Folio": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.transmissionbt.Transmission": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.tutanota.Tutanota": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
     "com.ulaa.Ulaa": {
         "finish-args-contains-both-x11-and-wayland": "Optional Wayland support",
@@ -1232,19 +1882,51 @@
         "finish-args-direct-dconf-path": "Access host dconf for proxy resolution",
         "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
     },
+    "com.ulduzsoft.Birdtray": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "com.ultimaker.cura": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "com.unity.UnityHub": {
         "finish-args-flatpak-spawn-access": "needed to spawn the flatpaked version of vscode from the editor",
         "finish-args-host-filesystem-access": "Predates the linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
-    "com.visualstudio.code": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    "com.usebottles.bottles": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "module-vmtouch-checker-tracks-commits": "Module is unmaintained for 2 years"
     },
-    "com.visualstudio.code.insiders": {
-        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+    "com.usebruno.Bruno": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.valvesoftware.Steam": {
+        "finish-args-contains-both-x11-and-wayland": "not every game supports wayland",
+        "finish-args-own-name-wildcard-com.steampowered": "Predates the linter rule"
+    },
+    "com.valvesoftware.Steam.CompatibilityTool.Proton-GE": {
+        "manifest-file-is-symlink": "Predates the linter rule"
+    },
+    "com.vba_m.visualboyadvance-m": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.vesc_project.VescTool": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.viber.Viber": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.vicr123.thebeat": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.virustotal.VirusTotalUploader": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "com.visualstudio.code": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule",
@@ -1255,6 +1937,34 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.visualstudio.code.insiders": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "com.vivaldi.Vivaldi": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "com.vkhitrin.cosmicding": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "com.voxdsp.Borg": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.voxdsp.Borg0": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.voxdsp.VoxelPaint": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.voxdsp.VoxelPaintPro": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "com.vscodium.codium": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
@@ -1268,23 +1978,296 @@
         "finish-args-has-socket-ssh-auth": "Predates the linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
+    "com.vysp3r.ProtonPlus": {
+        "finish-args-flatpak-spawn-access": "required to install and manage compatibility-runtimes on the host",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.vzhd1701.gridplayer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.wings3d.WINGS": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.wireframesketcher.WireframeSketcher": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "com.wiz.Note": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "com.wonderlandengine.editor": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "com.xnview.XnViewMP": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.yacreader.YACReader": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.zerobrane.studio": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "com.zettlr.Zettlr": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "com.zquestclassic.ZQuest": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "cz.zeropage.Formiko": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.akaflieg_freiburg.cavok.add_hours_and_minutes": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "de.akaflieg_freiburg.enroute": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "de.allotropia.ZetaOffice": {
+        "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "This was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/111> 'GTK bookmarks do not appear in the flatpak version of LibreOffice' in the org.libreoffice.LibreOffice app from which this app derives",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "This was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/136> 'fontconfig user configuration' in the org.libreoffice.LibreOffice app from which this app derives",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-de.allotropia.ZetaOfficeIpc0": "Predates the linter rule"
+    },
+    "de.bforartists.Bforartists": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.capypara.FieldMonitor": {
+        "finish-args-ssh-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "de.create3000.titania": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.danielnoethen.butt": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.desy.constellation": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.fabrik19.mos-Launcher": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.finnik.PassVault": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.flinkebits.AvaEmailArchivar": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "de.flose.Kochbuch": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.gonicus.gonnect": {
+        "finish-args-unnecessary-xdg-data-evolution-ro-access": "EDS exposes avatar images here, and GOnnect likes to display them on incoming calls."
+    },
+    "de.gunibert.Hackgregator": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "de.haeckerfelix.Fragments": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "de.hohnstaedt.xca": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.klayout.KLayout": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "de.leopoldluley.Clapgrep": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "de.lernsoftware_filius.Filius": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "de.linuxguides.RechnungsAssistent": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.manuel_kehl.go-for-it": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.marlam.qv": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.mediathekview.MediathekView": {
+        "finish-args-flatpak-spawn-access": "required to start VLC flatpak to view videos and live streams",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.nagstamon.nagstamon": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.philippun1.Snoop": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.philippun1.turtle": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "de.renew.Renew": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "de.rwth_aachen.ient.YUView": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "de.schmidhuberj.tubefeeder": {
+        "finish-args-flatpak-spawn-access": "Spawn arbitrary video player",
+        "finish-args-unnecessary-xdg-data-tubefeeder-create-access": "the app predates this linter rule"
+    },
+    "de.unifreiburg.ellipticcurve": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "de.willuhn.Jameica": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "de.wwwtech.ColorMate": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "de.z_ray.OptimusUI": {
         "finish-args-flatpak-spawn-access": "Requires use of prime-select, nvidia-prime-select or fedora-prime-select on the host; Furthermore it requires access to /etc/os-release on the host to determine the real host distribution to use the correct prime tool and enable / disable features in the UI"
+    },
+    "de.zwarf.picplanner": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "dev.aa55.yetty": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "dev.ares.ares": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "dev.bambosh.UnofficialHomestuckCollection": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "dev.boxi.Boxi": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "dev.bsnes.bsnes": {
+        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "needs access to xdg-config/gtk-3.0 for theming, does not support portals",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.edfloreshz.Calculator": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "dev.edfloreshz.CosmicTweaks": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write to system configuration files"
+    },
+    "dev.edfloreshz.Tasks": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "dev.ensoft.ecode": {
+        "finish-args-flatpak-spawn-access": "required to access language servers, linters and formatters installed on host",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "dev.gbstudio.gb-studio": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "dev.geopjr.Turntable": {
+        "finish-args-freedesktop-dbus-talk-name": "Required to gather and update the list of all available MPRIS clients",
+        "finish-args-flatpak-appdata-folder-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",
+        "finish-args-host-var-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
+        "finish-args-flatpak-system-folder-access": "Required to read .desktop files and icons for listing MPRIS clients",
+        "finish-args-full-home-cache-access": "Required to read the local MPRIS artUrl files from some MPRIS clients",
+        "finish-args-host-tmp-access": "Required to read the local MPRIS artUrl files from some MPRIS clients"
+    },
     "dev.goats.xivlauncher": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.heppen.webapps": {
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Access for reading installed browsers",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Access for writing desktop files for web apps",
+        "finish-args-unnecessary-xdg-data-icons-rw-access": "Access for writing icons into xdg-data/icons/QuickWebApps directory for created webapps",
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "For COSMIC desktop environment",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
+    },
+    "dev.jamiethalacker.window_painter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "dev.k8slens.OpenLens": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
     "dev.lapce.lapce": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
+    "dev.levz.TinyImageFinder": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
     "dev.lizardbyte.app.Sunshine": {
         "finish-args-flatpak-spawn-access": "needed to start applications",
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.lukebriggs.pepys": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.lunarsrl.NovaMusic": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "dev.mariinkys.Oboete": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "dev.mariinkys.StarryDex": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "dev.mrquantumoff.mcmodpackmanager": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.dev_mrquantumoff_mcmodpackmanager.SingleInstance": "Predates the linter rule"
+    },
+    "dev.neovide.neovide": {
+        "finish-args-flatpak-spawn-access": "required to allow spawning neovim on the host, terminal emulating, tools and command from host like podman, toolbox, compilers, etc",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "dev.overlayed.Overlayed": {
+        "flathub-json-automerge-enabled": "Allow merging of autobot PRs to keep webkitgtk updated"
+    },
+    "dev.paullee.scraterpreter.Scrape": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "dev.paullee.scraterpreter.Scrapec": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.pulsar_edit.Pulsar": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "dev.qwery.AddWater": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "dev.restfox.Restfox": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.schlaubi.Tonbrett": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "dev.serebit.Waycheck": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "dev.skynomads.Seabird": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.storyapps.starc": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "dev.tchx84.Portfolio": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.FileManager1": "Predates the linter rule"
+    },
+    "dev.tony4.subscribi": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "dev.vencord.Vesktop": {
+        "finish-args-contains-both-x11-and-wayland": "Running through native Wayland instead of X11 causes issues for a considerable number of users, but Wayland access is still needed for pipewire screen capturing"
     },
     "dev.zed.Zed": {
         "finish-args-flatpak-spawn-access": "application won't open without this permission set; also needed to spawn several tools and commands from the host",
@@ -1304,1964 +2287,34 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "es.estoes.wallpaperDownloader": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "eu.skribisto.skribisto": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-com.druide.antidote": "Predates the linter rule"
-    },
-    "io.atom.Atom": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.github.achetagames.epic_asset_manager": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.am2r_community_developers.AM2RLauncher": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.congard.qnvsm": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "io.github.dummerle.rare": {
-        "finish-args-flatpak-spawn-access": "Required to run Steam Linux Runtime based or host-native Steam compatibility tools (SteamRT/Proton) on the host",
-        "finish-args-home-filesystem-access": "needed for the default location to install games in",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "to create application shortcuts for games",
-        "finish-args-unnecessary-xdg-data-umu-ro-access": "to search for Steam compatibility tools managed by umu-launcher",
-        "finish-args-unnecessary-xdg-data-Steam-rw-access": "to search for Steam compatibility tools managed by Steam and create shortcuts in Steam's library"
-    },
-    "io.github.ezQuake": {
-        "appid-code-hosting-too-few-components": "the app predates this linter rule"
-    },
-    "io.github.giantpinkrobots.bootqt": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.jeffshee.Hidamari": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.jliljebl.Flowblade": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.maurycyliebner.enve": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
+    "edu.stanford.protege": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.mightycreak.Diffuse": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+    "ee.ria.qdigidoc4": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.mpobaschnig.Vaults": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.philipk.boilr": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required for showing which other Flatpaks are installed, so a shortcut can be added easly to Steam",
-        "finish-args-unnecessary-xdg-data-lutris-ro-access": "Required for reading the installed games in Lutris, so a shortcut can be added easly to Steam",
-        "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the shortcuts file in Steam, this is the purpose of BoilR",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.github.prateekmedia.appimagepool": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.randovania.Randovania": {
-        "finish-args-unnecessary-xdg-config-Ryujinx-rw-access": "required to export a randomizer to the host's Ryujinx settings",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.github.Qalculate": {
-        "appid-code-hosting-too-few-components": "the app predates this linter rule"
-    },
-    "io.github.realmazharhussain.GdmSettings": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-unnecessary-xdg-config-monitors.xml-ro-access": "required for 'apply current display settings to GDM' feature"
-    },
-    "io.github.shiftey.Desktop": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.gitlab.Goodvibes": {
-        "appid-code-hosting-too-few-components": "the app predates this linter rule"
-    },
-    "io.gitlab.librewolf-community": {
-        "appid-code-hosting-too-few-components": "the app predates this linter rule",
-        "finish-args-own-name-wildcard-io.gitlab.librewolf": "Predates the linter rule",
-        "finish-args-own-name-wildcard-io.gitlab.firefox": "Predates the linter rule"
-    },
-    "io.gitlab.liferooter.TextPieces": {
-        "finish-args-flatpak-spawn-access": "required for running user-defined text actions in host environment"
-    },
-    "io.howl.Editor": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-io.howl": "Predates the linter rule"
-    },
-    "io.podman_desktop.PodmanDesktop": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.stoplight.studio": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "net.nymtech.NymVPN": {
-        "finish-args-host-var-access": "needed to access the daemon logs"
-    },
-    "net.codelogistics.webapps": {
-        "finish-args-arbitrary-xdg-data-rw-access": "The app creates and removes desktop files in ~/.local/share/applications."
-    },
-    "net.cozic.joplin_desktop": {
-        "external-gitmodule-url-found": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.davidotek.pupgui2": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "net.lutris.Lutris": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-data-umu-create-access": "Uses shared installation for the umu runtime",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.retrodeck.retrodeck": {
-        "finish-args-unnecessary-xdg-data-Steam-rw-access": "SteamOS is the primary target of the application and it does not ship an xsettings daemon or xdg-desktop-portal-gtk: https://github.com/ValveSoftware/SteamOS/issues/803",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "SteamOS is the primary target of the application and it does not ship an xsettings daemon or xdg-desktop-portal-gtk: https://github.com/ValveSoftware/SteamOS/issues/803",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-talk-name": "Predates the linter rule"
-    },
-    "net.veloren.veloren": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.cockpit_project.CockpitClient": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "org.contourterminal.Contour": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "org.coolero.Coolero": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "org.cryptomator.Cryptomator": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.flatpak.Builder": {
-        "*": "used by flathub infra",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.flatpak.Builder.BaseApp": {
-        "*": "used by flathub infra"
-    },
-    "org.flathub.flatpak-external-data-checker": {
-        "*": "used by flathub infra",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.freecad.FreeCAD": {
-        "finish-args-flatpak-spawn-access": "Needed to launch OpenSCAD flatpak as a command-line tool for the importer.",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "se.emijoh.mpw": {
-        "finish-args-not-defined": "It is a command line package"
-    },
-    "org.gabmus.gfeeds": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "org.gabmus.hydrapaper": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gabmus.unifydmin": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-ssh-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Lollypop": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
-    },
-    "org.gnome.World.PikaBackup": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to mount xdg-data/flatpak:ro to undo the tmpfs mount Flatpak does on --filesystem=host. The directory contains the Flatpak privileges overrides and app data that some people want to include in their backups.",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.godotengine.Godot": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Godot will fail to start up in Wayland sessions as X11 is still the default. The change this error arises from, https://github.com/flathub/org.godotengine.Godot/pull/170, predates this linter rule.",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.godotengine.Godot3": {
-        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.godotengine.Godot3Sharp": {
-        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.godotengine.GodotSharp": {
-        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
-        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Godot will fail to start up in Wayland sessions as X11 is still the default.",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.jabref.jabref": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.dolphin": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.gwenview": {
-        "finish-args-unnecessary-xdg-data-Trash-rw-access": "required for access to Trash until Portal support is added",
-        "finish-args-unnecessary-xdg-cache-thumbnails-rw-access": "required for thumbnail reading and generation",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kate": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kdevelop": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.kdevelop": "Predates the linter rule"
-    },
-    "org.kde.kile": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kjournaldbrowser": {
-        "finish-args-host-var-access": "required for read access to system journal log database"
-    },
-    "org.kde.konsole": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.qmlkonsole": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
-    },
-    "org.kde.yakuake": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-kwin-talk-name": "Predates the linter rule",
-        "finish-args-plasmashell-talk-name": "Predates the linter rule"
-    },
-    "org.mozilla.Thunderbird": {
-        "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system",
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.mozilla.thunderbird": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.mozilla.thunderbird_beta": "Predates the linter rule"
-    },
-    "org.octave.Octave": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.openshot.OpenShot": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.pegasus_frontend.Pegasus": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.sil.FieldWorks": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.texstudio.TeXstudio": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.ultimatepp.TheIDE": {
-        "finish-args-flatpak-spawn-access": "required to execute various host binaries, including compiler, debugger, and git within the application",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.vim.Vim": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.wezfurlong.wezterm": {
-        "finish-args-flatpak-spawn-access": "required to spawn the user's shell and other commands on the host system; it's the primary purpose of a terminal emulator",
-        "finish-args-unnecessary-xdg-config-wezterm-rw-access": "required to access host configs, repos, workspaces and so on. https://github.com/flathub-infra/flatpak-builder-lint/issues/270",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.zim_wiki.Zim": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "pm.mirko.Atoms": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "re.sonny.Junction": {
-        "finish-args-flatpak-spawn-access": "required to launch apps",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "required to list apps",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "required to list apps",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.google.Chrome": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
-    },
-    "com.google.ChromeDev": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
-    },
-    "org.chromium.Chromium": {
-        "finish-args-contains-both-x11-and-wayland": "optional wayland support",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.scribus.Scribus": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.valvesoftware.Steam": {
-        "finish-args-contains-both-x11-and-wayland": "not every game supports wayland",
-        "finish-args-own-name-wildcard-com.steampowered": "Predates the linter rule"
-    },
-    "org.inkscape.Inkscape": {
-        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "Access xdg-config/gtk-3.0 for bookmarks",
-        "finish-args-contains-both-x11-and-wayland": "it can launch non-wayland UI via plugins",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.adamcake.Bolt": {
-        "finish-args-unnecessary-xdg-data-icons-create-access": "individual games' window icons need to be downloaded and copied to xdg-data/icons as the user installs or updates them",
-        "finish-args-contains-both-x11-and-wayland": "some games support wayland and some don't"
-    },
-    "com.adobe.Flash-Player-Projector": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.albiononline.AlbionOnline": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.amazon.Workspaces": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.anydesk.Anydesk": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.behringer.XAirEdit": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.dropbox.Client": {
-        "finish-args-own-name-wildcard-org.kde": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.fightcade.Fightcade": {
-        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function"
-    },
-    "com.flashforge.FlashPrint": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.getpostman.Postman": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.icons8.Lunacy": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.jagex.RuneScape": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.lunarclient.LunarClient": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.microsoft.Edge": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "com.skype.Client": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.slack.Slack": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.sublimemerge.App": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
-        "finish-args-own-name-com.sublimemerge": "Predates the linter rule"
-    },
-    "com.sublimetext.three": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.synology.CloudStationBackup": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.synology.SynologyDrive": {
-        "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.syntevo.SmartGit": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.teamspeak.TeamSpeak": {
-        "finish-args-unnecessary-xdg-config-TeamSpeak-rw-access": "TeamSpeak 6 plugins installation directory.",
-        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Teamspeak will crash when audio or hotkey settings are opened"
-    },
-    "com.tencent.WeChat": {
-        "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"
-    },
-    "com.ticktick.TickTick": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.viber.Viber": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.botfather.Botfather": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.exodus.Exodus": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.Archeb.opentrace": {
-        "finish-args-flatpak-spawn-access": "This app uses org.freedesktop.Flatpak to provide ability to run nexttrace with cap_net_raw, which is necessary for a traceroute app"
-    },
-    "io.github.Fndroid.clash_for_windows": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.ihhub.Fheroes2": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "io.github.MakovWait.Godots": {
-        "finish-args-flatpak-spawn-access": "flatpak-spawn is needed for blender and external code editors",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.wavebox.Wavebox": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "jp.yvt.OpenSpades": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "me.dusansimic.DynamicWallpaper": {
-        "finish-args-unnecessary-xdg-data-backgrounds-create-access": "https://github.com/dusansimic/dynamic-wallpaper/issues/5",
-        "finish-args-unnecessary-xdg-data-gnome-background-properties-create-access": "https://github.com/dusansimic/dynamic-wallpaper/issues/5"
-    },
-    "me.amankhanna.opendeck": {
-        "finish-args-flatpak-spawn-access": "host shell access required for running user-provided commands and also to start plugins using Wine and Node"
-    },
-    "me.timschneeberger.GalaxyBudsClient": {
-        "finish-args-own-name-wildcard-org.kde": "The used version of the toolkit Avalonia only supports legacy KDE system tray icons: https://github.com/AvaloniaUI/Avalonia/issues/13782"
-    },
-    "org.firestormviewer.FirestormViewer": {
-        "finish-args-own-name-com.secondlife.ViewerAppAPIService": "Predates the linter rule"
-    },
-    "org.freefilesync.FreeFileSync": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.geogebra.GeoGebra": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.xfce.ristretto": {
-        "finish-args-arbitrary-dbus-access": "https://github.com/flathub/flathub/issues/2770",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.mediathekview.MediathekView": {
-        "finish-args-flatpak-spawn-access": "required to start VLC flatpak to view videos and live streams",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.schmidhuberj.tubefeeder": {
-        "finish-args-flatpak-spawn-access": "Spawn arbitrary video player",
-        "finish-args-unnecessary-xdg-data-tubefeeder-create-access": "the app predates this linter rule"
-    },
-    "com.helix_editor.Helix": {
-        "finish-args-flatpak-spawn-access": "required to access language servers installed on host",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "dev.ensoft.ecode": {
-        "finish-args-flatpak-spawn-access": "required to access language servers, linters and formatters installed on host",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "codes.merritt.Nyrna": {
-        "finish-args-flatpak-spawn-access": "required to access and change process status on the host"
-    },
-    "io.github.kotatogram": {
-        "appid-code-hosting-too-few-components": "the app predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "external-gitmodule-url-found": "Predates the linter rule",
-        "module-tg_owt-checker-tracks-commits": "Manually updated, grandfathered"
-    },
-    "io.github.Hexchat": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
-    },
-    "io.github.ImEditor": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.OpenToonz": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Pithos": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
-    },
-    "io.github.Soundux": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "io.github.qnapi": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.github.TransmissionRemoteGtk": {
-        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
-    },
-    "com.diffingo.fwbackups": {
-        "finish-args-flatpak-spawn-access": "required to backup and restore installed packages",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.gnome.font-viewer": {
-        "finish-args-unnecessary-xdg-data-fonts-create-access": "required to save fonts"
-    },
-    "page.codeberg.JakobDev.jdAppStreamEdit": {
-        "finish-args-flatpak-spawn-access": "required for preview in Gnome Software"
-    },
-    "page.codeberg.JakobDev.jdFlatpakSnapshot": {
-        "finish-args-flatpak-spawn-access": "Needed to call flatpak to get some Information and check if a Flatpak is currently running",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needs access to the Flatpak directory",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
-    },
-    "io.github.zyedidia.micro": {
-        "finish-args-flatpak-spawn-access": "users may want to use it for built-in terminal emulator",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.mmstick.FontFinder": {
-        "finish-args-unnecessary-xdg-data-fonts-create-access": "This program is designed to store font files in the font directory",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.dec05eba.gpu_screen_recorder": {
-        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn to capture a monitor on AMD/Intel GPUs",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "page.codeberg.JakobDev.jdSimpleAutostart": {
-        "finish-args-unnecessary-xdg-config-autostart-create-access": "the app predates this linter rule",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "the app predates this linter rule",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "Needs to read desktop files",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-autostart-filesystem-access": "Predates the linter rule"
-    },
-    "page.codeberg.JakobDev.jdMinecraftLauncher": {
-        "finish-args-unnecessary-xdg-data-applications-create-access": "jdMinecraftLauncher creates .desktop files in share/applications",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "it.mijorus.gearlever": {
-        "finish-args-flatpak-spawn-access": "Required to launch AppImages that the user integrates into the system menu",
-        "finish-args-host-tmp-access": "Required to extract some large AppImages into the /tmp directory: the tmpfs under /run/user/1000 might be too small",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "page.codeberg.JakobDev.jdTextEdit": {
-        "finish-args-flatpak-spawn-access": "Neded to execute external commands",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.missioncenter.MissionCenter": {
-        "finish-args-flatpak-spawn-access": "access to /proc is required in order to list running processes and their respective resource usage; see https://github.com/flathub/flathub/pull/4313#discussion_r1257263670",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "read-only access to xdg-data/flatpak{,/exports/share} is required to query installed apps on the system and present the ones that are running to the user; see https://github.com/flathub/flathub/pull/4313#discussion_r1257263670",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-systemd1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.unrud.RecentFilter": {
-        "finish-args-arbitrary-xdg-data-rw-access": "Requires full access to xdg-data/recently-used.xbel",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnu.emacs": {
-        "finish-args-flatpak-spawn-access": "required to access external tools since the Emacs ecosystem expects to lean heavily on them",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.nokse22.inspector": {
-        "finish-args-flatpak-spawn-access": "Needed to execute external commands to show informations about your computer",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.Youda008.DoomRunner": {
-        "finish-args-flatpak-spawn-access": "Needed to execute external game engines",
-        "finish-args-home-filesystem-access": "Needed to browse external game files and folders"
-    },
-    "xyz.tytanium.DoorKnocker": {
-        "finish-args-flatpak-spawn-access": "Required to get/check xdg-desktop-portal version"
-    },
-    "page.codeberg.JakobDev.jdDBusDebugger": {
-        "finish-args-arbitrary-dbus-access": "It's a D-Bus Debugger",
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "com.pojtinger.felicitas.Multiplex": {
-        "finish-args-flatpak-spawn-access": "Needed to execute external copies of MPV and control them via IPC",
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "io.github.flattool.Warehouse": {
-        "finish-args-flatpak-spawn-access": "Required to manage Flatpaks on the host",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule"
-    },
-    "io.github.jean28518.Linux-Assistant": {
-        "finish-args-flatpak-spawn-access": "Required to get information about the os and execute host commands e.g. like the package managers",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.nokyan.Resources": {
-        "finish-args-flatpak-spawn-access": "Required to spawn a small executable dedicated to finding running processes in /proc",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to detect user-wide installed Flatpak applications by searching for .desktop files",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.everestapi.Olympus": {
-        "finish-args-flatpak-spawn-access": "Required to be able to launch the modded Celeste game outside of the flatpak sandbox",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.obsproject.Studio": {
-        "finish-args-flatpak-spawn-access": "Required for the virtual camera feature",
-        "external-gitmodule-url-found": "Flatpak are published by upstream from their own repo",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.thetumultuousunicornofdarkness.cpu-x": {
-        "finish-args-flatpak-spawn-access": "access to /dev/cpu and /dev/mem is required in order to display data about CPU and memory"
     },
     "engineer.atlas.Nyxt": {
         "finish-args-flatpak-spawn-access": "Required access to external tools since Nyxt ecosystem expects to rely heavily on them",
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "page.codeberg.JakobDev.jdProcessFileWatcher": {
-        "finish-args-flatpak-spawn-access": "Run strace on the Host",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "Needs to read desktop files",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needs to read desktop files",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
-    },
-    "io.github.dvlv.boxbuddyrs": {
-        "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host",
+    "es.danirod.Cartero": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.kapsa.drive": {
-        "finish-args-flatpak-spawn-access": "Required to spawn fusermount3 in order to run FUSE mount on a host system",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.calibre_ebook.calibre": {
-        "finish-args-unnecessary-xdg-data-Trash-rw-access": "Needs direct trash access, doesn't use portal",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "app.drey.KeyRack": {
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "the app predates this linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule"
-    },
-    "com.discordapp.Discord": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
-    },
-    "com.discordapp.DiscordCanary": {
-        "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients are forced to update",
-        "finish-args-contains-both-x11-and-wayland": "The client currently crashes if --socket=wayland and --socket=fallback-x11 are used"
-    },
-    "us.zoom.Zoom": {
-        "finish-args-own-name-wildcard-org.kde": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.kde.SymbolEditor": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.ark": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.artikulate": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.blinken": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.cantor": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.digikam": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.elisa": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.falkon": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.filelight": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.gcompris": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.index": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.isoimagewriter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.juk": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kaffeine": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kalzium": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kamoso": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kanagram": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kbibtex": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kbruch": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kcachegrind": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kcalc": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kcolorchooser": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kdenlive": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kdiff3": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kfind": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kgeography": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kgraphviewer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.khangman": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kid3": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kig": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kimagemapeditor": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kiten": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kleopatra": {
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kwatchgnupg": "Predates the linter rule"
-    },
-    "org.kde.klettres": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kmplot": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kmymoney": {
-        "finish-args-home-filesystem-access": "required for writing and deleting backup and temporary files",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.koko": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kolourpaint": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kommit": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.kde.kompare": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kongress": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-own-name-org.kde.kongressac": "Predates the linter rule"
-    },
-    "org.kde.kontact": {
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.Akonadi": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Akonadi": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Akonadi.Agent": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Akonadi.Control": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Akonadi.Resource": "Predates the linter rule",
-        "finish-args-own-name-org.kde.accountwizard": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.kde.akonadiconsole": "Predates the linter rule",
-        "finish-args-own-name-org.kde.akregator": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kaddressbook": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kalarm": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kalendarac": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.kde.kioexec": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kmail": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kmail2": "Predates the linter rule",
-        "finish-args-own-name-org.kde.korgac": "Predates the linter rule",
-        "finish-args-own-name-org.kde.korganizer": "Predates the linter rule",
-        "finish-args-own-name-org.kde.merkuro": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.kde.pim": "Predates the linter rule",
-        "finish-args-own-name-org.kde.pimsettingexporter": "Predates the linter rule",
-        "finish-args-own-name-org.kde.sieveeditor": "Predates the linter rule"
-    },
-    "org.kde.konversation": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.krdc": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.krename": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kronometer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kruler": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kstars": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kteatime": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.ktimetracker": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.ktorrent": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.ktouch": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.kde.kturtle": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kwordquiz": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.kwrite": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.kxstitch": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.kde.labplot2": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.lokalize": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.marble": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.kde.minuet": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.okteta": {
-        "appstream-missing-developer-name": "grandfathered due to unannounced linter changes",
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.okular": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-talk-name": "Predates the linter rule"
-    },
-    "org.kde.parley": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.peruse": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.pix": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.rocs": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.skanpage": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.tellico": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.umbrello": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-own-name-org.kde.umbrello-2": "Predates the linter rule"
-    },
-    "org.kde.vvave": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.trojita": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.spectacle": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-kwin-talk-name": "Predates the linter rule",
-        "finish-args-plasmashell-talk-name": "Predates the linter rule"
-    },
-    "org.kde.ktechlab": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kde.krusader": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.amarok": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.skanlite": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.Sunderland93.sway-input-config": {
-        "finish-args-unnecessary-xdg-config-sway-rw-access": "Required to access Sway configuration on host"
-    },
-    "org.linuxshowplayer.LinuxShowPlayer": {
-        "finish-args-flatpak-spawn-access": "Required by CommandCue(s) to allow users to interact with external tools",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.neovide.neovide": {
-        "finish-args-flatpak-spawn-access": "required to allow spawning neovim on the host, terminal emulating, tools and command from host like podman, toolbox, compilers, etc",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.core447.StreamController": {
-        "finish-args-flatpak-spawn-access": "required to allow plugins to open apps on the host",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "page.kramo.Cartridges": {
-        "finish-args-flatpak-spawn-access": "required to launch games on the host",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "access to xdg-data/flatpak/app and exports is needed to import games installed as user flatpaks",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "page.codeberg.JakobDev.jdMacroPlayer": {
-        "finish-args-flatpak-spawn-access": "Run ydotoold on the Host",
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "com.brave.Browser": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Access host tmp for MPRIS media cover art",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "app.lith.Lith": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "ar.com.softwareperonista.Rockarrolla": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "art.taunoerik.tauno-monitor": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "br.app.pw3270.terminal": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "ca._0ldsk00l.Nestopia": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "cc.arduino.arduinoide": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.bixense.PasswordCalculator": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.bladecoder.adventure-editor": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.doycho.euterpe.gtk": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.endlessm.photos": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.frac_tion.teleport": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.hack_computer.OperatingSystemApp": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "dev.overlayed.Overlayed": {
-        "flathub-json-automerge-enabled": "Allow merging of autobot PRs to keep webkitgtk updated"
-    },
-    "com.hack_computer.Sidetrack": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.kavilgroup.gelectrical": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.kavilgroup.gestimator": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.mattjakeman.ExtensionManager": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.ozmartians.VidCutter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.realm667.Wolfenstein_Blade_of_Agony": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.rosegardenmusic.rosegarden": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sourcepole.kadas": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.teeworlds.Teeworlds": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.ultimaker.cura": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.wings3d.WINGS": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.zquestclassic.ZQuest": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "de.gunibert.Hackgregator": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "de.philippun1.Snoop": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.jamiethalacker.window_painter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "de.wwwtech.ColorMate": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "de.zwarf.picplanner": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    "es.estoes.wallpaperDownloader": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "eu.ad5001.LogarithmPlotter": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
-    "id.sideka.App": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "im.gitter.Gitter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "info.bibletime.BibleTime": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "info.olasagasti.revelation": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.aerocyber.sitemarker": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.amit9838.mousam": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.betaflight.BetaflightConfigurator": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.dida_code.OpstaKultura": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.diegoivanme.flowtime": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.diegoivan.pdf_metadata_editor": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.diegopvlk.Dosage": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.dyegoaurelio.simple-wireplumber-gui": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-unnecessary-xdg-config-wireplumber-create-access": "this program creates config files in xdg-config/wireplumber"
-    },
-    "io.github.fabrialberio.pinapp": {
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "This program needs read-access to xdg-data/flatpak",
-        "finish-args-unnecessary-xdg-data-applications-rw-access": "This program needs read-write access to xdg-data/applications",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+    "eu.betterbird.Betterbird": {
         "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-autostart-filesystem-access": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.mozilla.betterbird": "Predates the linter rule"
     },
-    "io.github.fizzyizzy05.binary": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    "eu.binjr.binjr": {
+        "finish-args-host-filesystem-access": "Application loads source files (logs, csv, rrd) from any location the user requires and writes saved workspace in arbitrary location in user's home or and mounted filesystems"
     },
-    "io.github.limads.Queries": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.martinrotter.textosaurus": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.mki1967.mki3dgame": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.github.nate_xyz.Chromatic": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.nate_xyz.Conjure": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.nate_xyz.Resonance": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.nokse22.teleprompter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.nokse22.ultimate-tic-tac-toe": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.OkuBrowser.oku": {
-        "finish-args-flatpak-spawn-access": "Required to spawn fusermount3 in order to run FUSE mount on a host system",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.orontee.Argos": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.phastmike.tags": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.qwersyk.Newelle": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.RodZill4.Material-Maker": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.thiefmd.themegenerator": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.gitlab.celleron56.libretile": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.gitlab.gwendalj.package-transporter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
-    },
-    "io.liri.Calculator": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.mgba.mGBA": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.otsaloma.gaupol": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.otsaloma.nfoview": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "it.mijorus.collector": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "it.mijorus.smile": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "it.mijorus.whisper": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "me.iepure.devtoolbox": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "me.sanchezrodriguez.passes": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.danigm.loop": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.lugsole.bible_gui": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.mediaarea.AVIMetaEdit": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.mediaarea.DVAnalyzer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.mediaarea.MediaConch": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.mediaarea.MOVMetaEdit": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.mediaarea.QCTools": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.oz9aec.Gpredict": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "net.redeclipse.RedEclipse": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.runelite.RuneLite": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.sourceforge.Chessx": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.sourceforge.electrip.Electrip": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.sourceforge.Fillets": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.sourceforge.projectM": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "net.sourceforge.Teo": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.adishatz.syncpasswd": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.apache.netbeans": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.azahar_emu.Azahar": {
-        "finish-args-unnecessary-xdg-data-applications-create-access": "Azahar has a feature which creates .desktop files in ~/.local/share/applications",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.chrisoft.qmidiplayer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.davmail.DavMail": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.develz.Crawl": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.eclipse.iot.fourdiac.Ide": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.fedoraproject.MediaWriter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.fritzing.Fritzing": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.gahshomar.Gahshomar": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnode.NixView": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Boxes": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Calendar": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.Characters": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.ColorViewer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Connections": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Devhelp": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.eog": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Evolution": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Geary": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.gedit": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.gitlab.bazylevnik0.Convolution": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.gitlab.Cowsay": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.gitlab.johannesjh.favagtk": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.gThumb": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.HexGL": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Loupe": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.meld": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.moserial": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Music": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.NetworkDisplays": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Notes": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.OfficeRunner": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.Polari": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-own-name-org.freedesktop.Telepathy.Client.Polari": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Telepathy.Client.Polari": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Telepathy.Client.TpGLibRequestAndHandle": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.Telepathy.AccountManager": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.Telepathy.ChannelDispatcher": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.Telepathy.MissionControl5": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.Telepathy.ConnectionManager.idle": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Telepathy.Connection.idle.irc": "Predates the linter rule"
-    },
-    "org.gnome.PowerStats": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Recipes": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Rhythmbox3": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.Shotwell": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.SoundJuicer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.SoundRecorder": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.SwellFoop": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.gnome.TextEditor": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Totem": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.keepassxc.KeePassXC": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.secrets": "Predates the linter rule"
-    },
-    "org.KekikAkademi.BTKSorgu": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kekikakademi.eFatura": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.kekikakademi.ntvHaber": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.libsdl.Maelstrom": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.mapeditor.Tiled": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.neverball.Neverball": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.nickvision.cavalier": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.openclonk.OpenClonk": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.openmw.OpenMW": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.openttd.OpenTTD": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.processing.processingide": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.pyzo.pyzo": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.qgis.qgis": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.quassel_irc.QuasselClient": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.quetoo.Quetoo": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.raceintospace.Raceintospace": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.remmina.Remmina": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-flatpak-spawn-access": "Needed to launch programs on the host specified by the user",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.shadered.SHADERed": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.solarus_games.solarus.Launcher": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.tabos.maxcontrol": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.tabos.saldo": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.thonny.Thonny": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.xonotic.Xonotic": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "page.codeberg.Imaginer.Imaginer": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "se.manyver.Manyverse": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "work.openpaper.Paperwork": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-work.openpaper.paperwork": "Predates the linter rule"
-    },
-    "xyz.slothlife.Jogger": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "com.oyajun.ColorCode": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "io.github.nyre221.kiview": {
-        "finish-args-wildcard-kde-talk-name": "Required to send commands to the active dolphin window.",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.ghostwriter": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
-    },
-    "org.goldendict.GoldenDict": {
-        "module-goldendict-source-git-branch": "Needed for x-checker as upstream does not tag releaases."
-    },
-    "net.rpcs3.RPCS3": {
-        "module-rpcs3-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation.",
-        "flathub-json-automerge-enabled": "Grandfather in on condition of weekly update workflow. Without automerge builds fail as branch moves to another SHA",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.loot.loot": {
-        "finish-args-unnecessary-xdg-config-heroic-ro-access": "Needed to detect games installed through Heroic Games Launcher.",
-        "finish-args-unnecessary-xdg-config-openmw-rw-access": "Needed to detect and make changes to OpenMW when it is installed as a distribution package.",
-        "finish-args-unnecessary-xdg-data-openmw-ro-access": "Needed to read OpenMW data when it is installed as a distribution package.",
-        "finish-args-unnecessary-xdg-data-Steam-ro-access": "Needed to detect and make changes to games installed through Steam.",
-        "finish-args-unnecessary-xdg-data-Steam-rw-access": "Needed to detect and make changes to games installed through Steam.",
-        "finish-args-flatpak-appdata-folder-access": "Needed to detect and make changes to games installed through Steam and Heroic Games Launcher.",
-        "finish-args-flatpak-system-folder-access": "Needed to read the OpenMW install folder when it is installed as a system Flatpak.",
-        "finish-args-flatpak-user-folder-access": "Needed to read the OpenMW install folder when it is installed as a user Flatpak."
-    },
-    "io.github.pantheon_tweaks.pantheon-tweaks": {
-        "finish-args-flatpak-spawn-access": "Needed to get XDG_DATA_DIRS with flatpak-swapn to bridge host's GSettings.",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-legacy-icon-folder-permission": "DE tweak app",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "ch.tlaun.TL": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.adilhanney.ricochlime": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.adilhanney.saber": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.adilhanney.super_nonogram": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.atlauncher.ATLauncher": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.cassidyjames.butler": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.cassidyjames.plausible": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.inochi2d.inochi-creator": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.quexten.Goldwarden": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "com.redis.RedisInsight": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.steamgriddb.SGDBoop": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Read-only access to /var/lib/flatpak/app/com.valvesoftware.Steam to check whether Steam Flatpak is installed"
-    },
-    "com.steamgriddb.steam-rom-manager": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.tominlab.wonderpen": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "dev.schlaubi.Tonbrett": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "dev.serebit.Waycheck": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "dev.skynomads.Seabird": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.storyapps.starc": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "eu.quelltext.open_chakra_toning": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "eu.vcmi.VCMI": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "fi.skyjake.Lagrange": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "im.fluffychat.Fluffychat": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-own-name-chat.fluffy.fluffychat": "Predates the linter rule"
-    },
-    "info.portfolio_performance.PortfolioPerformance": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.gopher64.gopher64": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "io.github.kukuruzka165.materialgram": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "external-gitmodule-url-found": "Predates the linter rule",
-        "module-tg_owt-checker-tracks-commits": "Manually updated, grandfathered",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.nearinfinitybrowser.nearinfinity": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.sharkwouter.Minigalaxy": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.github.waylyrics.Waylyrics": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "io.github.wiiznokes.fan-control": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "io.github.xiaoyifang.goldendict_ng": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "md.obsidian.Obsidian": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "net.werwolv.ImHex": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "network.loki.Session": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org._2009scape.Launcher": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "org.easyrpg.player": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.freedesktop.Sdk.Extension.golang": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "org.freedesktop.Sdk.Extension.rust-stable": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "org.librepcb.LibrePCB": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.naev.Naev": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "org.otfried.Ipe": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "org.prismlauncher.PrismLauncher": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.purei.Play": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.radare.iaito": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "org.zrythm.Zrythm": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "rocks.koreader.KOReader": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.armcord.ArmCord": {
-        "flathub-json-automerge-enabled": "Predates the linter rule"
-    },
-    "uk.org.greenend.chiark.sgtatham.putty": {
-        "appid-too-many-components-for-app": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "uk.org.greenend.chiark.sgtatham.puzzles": {
-        "appid-too-many-components-for-app": "Predates the linter rule"
-    },
-    "app.rednotebook.RedNotebook": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ar.com.tuxguitar.TuxGuitar": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "at.priv.toastfreeware.ConfClerk": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "ca.parallel_launcher.ParallelLauncher": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-talk-name": "Predates the linter rule"
-    },
-    "cc.retroshare.retroshare-gui": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "ch.openboard.OpenBoard": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "chat.quadrix.Quadrix": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "chat.rocket.RocketChat": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.abagames.rRootage": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.chez.GrafX2": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.freerdp.FreeRDP": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.heroicgameslauncher.hgl": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-data-umu-create-access": "Uses shared installation for the umu runtime",
-        "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Access shared MangoHud configuration files",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "com.katawa_shoujo.KatawaShoujo": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.logseq.Logseq": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.mastermindzh.tidal-hifi": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.mattermost.Desktop": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.microsoft.EdgeDev": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "com.milesalan.mepo": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.modrinth.ModrinthApp": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.mousepawmedia.omission": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule"
-    },
-    "com.opera.Opera": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "com.pot_app.pot": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.revolutionarygamesstudio.ThriveLauncher": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.shatteredpixel.shatteredpixeldungeon": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.slugchess.SlugChess": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.supermodel3.Supermodel": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.tutanota.Tutanota": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.usebottles.bottles": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "module-vmtouch-checker-tracks-commits": "Module is unmaintained for 2 years"
-    },
-    "com.vivaldi.Vivaldi": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "com.wiz.Note": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "com.xnview.XnViewMP": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.akaflieg_freiburg.cavok.add_hours_and_minutes": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "de.flinkebits.AvaEmailArchivar": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "de.klayout.KLayout": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.unifreiburg.ellipticcurve": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "de.willuhn.Jameica": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+    "eu.codepoems.xl-converter": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "eu.ototu.Quteqoin": {
@@ -3270,11 +2323,82 @@
     "eu.planete_kraus.Tarot": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
+    "eu.quelltext.open_chakra_toning": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "eu.scarpetta.PDFMixTool": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "eu.skribisto.skribisto": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-com.druide.antidote": "Predates the linter rule"
+    },
+    "eu.vcmi.VCMI": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "fi.mooc.tmc.tmc-cli-rust": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "fi.skyjake.Lagrange": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "fm.helio.Workstation": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "fm.reaper.Reaper": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "fr.dwightstudio.JArmEmu": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "fr.fgrabenstaetter.DigitalAssets": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
+    "fr.free.Homebank": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "fr.free.qccrypt.Qccrypt": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "fr.handbrake.ghb": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "fr.inria.corese.CoreseCommand": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "fr.inria.corese.CoreseGui": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "fr.natron.Natron": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "fr.nytuo.cosmiccomics": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "fr.sgued.bodev": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write to system configuration files"
+    },
     "ga.rpmtw.rpmlauncher": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "gg.minion.Minion": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "id.sideka.App": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "im.dino.Dino": {
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule"
+    },
+    "im.fluffychat.Fluffychat": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-own-name-chat.fluffy.fluffychat": "Predates the linter rule"
+    },
+    "im.gitter.Gitter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "im.kaidan.kaidan": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -3292,33 +2416,481 @@
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "info.bibletime.BibleTime": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "info.cemu.Cemu": {
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "info.mumble.Mumble": {
+        "finish-args-own-name-net.sourceforge.mumble.mumble": "Predates the linter rule"
+    },
+    "info.olasagasti.revelation": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "info.portfolio_performance.PortfolioPerformance": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "info.puredata.Pd": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "info.puredata.Pd-extended": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "info.smplayer.SMPlayer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.appflowy.AppFlowy": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-io.appflowy.appflowy": "Predates the linter rule"
+    },
+    "io.atom.Atom": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.beekeeperstudio.Studio": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.blockloader.BlockLoader": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "io.botfather.Botfather": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.conduktor.Conduktor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.dbeaver.DBeaverCommunity": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.edcd.EDMarketConnector": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "io.enpass.Enpass": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.secrets": "Predates the linter rule"
+    },
+    "io.exodus.Exodus": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.frama.tractor.carburetor": {
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule"
+    },
+    "io.frappe.books": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "io.gdevelop.ide": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.Adda0.Stardrop": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Archeb.opentrace": {
+        "finish-args-flatpak-spawn-access": "This app uses org.freedesktop.Flatpak to provide ability to run nexttrace with cap_net_raw, which is necessary for a traceroute app"
+    },
+    "io.github.BuddySirJava.SSH-Studio": {
+        "finish-args-ssh-filesystem-access": "This app's main functionality is to edit ssh connections located in ~/.ssh/config",
+        "finish-args-has-socket-ssh-auth": "Needed for testing ssh connections (Located in HostEditor)"
+    },
+    "io.github.Cockatrice.cockatrice": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.DenysMb.Kontainer": {
+        "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host",
+        "finish-args-desktopfile-filesystem-access": "Needed to list exported apps from distroboxes"
+    },
+    "io.github.DraqueT.PolyGlot": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Faugus.faugus-launcher": {
+        "finish-args-contains-both-x11-and-wayland": "Without socket=X11 Winetricks doesn't work on Wayland and without socket=wayland the Wine Wayland driver doesn't work.",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Required for MangoHud to detect the settings file."
+    },
+    "io.github.Fndroid.clash_for_windows": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.Foldex.AdwSteamGtk": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "io.github.Hexchat": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
+    },
+    "io.github.ImEditor": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.JaGoLi.ytdl_gui": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.JakubMelka.Pdf4qt": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.KangLin.RabbitRemoteControl": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.github.MakovWait.Godots": {
+        "finish-args-flatpak-spawn-access": "flatpak-spawn is needed for blender and external code editors",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.N3kosempai.klia-store": {
+        "finish-args-flatpak-spawn-access": "Klia Store is a Flatpak application manager that needs to execute flatpak commands on the host system using flatpak-spawn to install, update, and manage other Flatpak applications.",
+        "finish-args-flatpak-system-talk-name": "Required to communicate with the Flatpak system service (org.freedesktop.Flatpak) to manage both user and system-level Flatpak installations.",
+        "finish-args-flatpak-system-folder-access": "Read-only access to /var/lib/flatpak is required to list and display information about system-installed Flatpak applications.",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Read-only access to XDG_DATA_HOME/flatpak is required to list and display information about user-installed Flatpak applications.",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Read-only access to XDG_DATA_HOME/applications is required to display desktop entries and application metadata for installed Flatpak applications."
+    },
+    "io.github.OkuBrowser.oku": {
+        "finish-args-flatpak-spawn-access": "Required to spawn fusermount3 in order to run FUSE mount on a host system",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Omniaevo.mqtt5-explorer": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.OpenToonz": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Pithos": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
+    },
+    "io.github.Q1CHENL.fig": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Qalculate": {
+        "appid-code-hosting-too-few-components": "the app predates this linter rule"
+    },
+    "io.github.Querz.mcaselector": {
+        "finish-args-flatpak-appdata-folder-access": "To open and edit Minecraft worlds files under launchers packages as Flatpak applications"
+    },
+    "io.github.Rangi42.polished-map": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Rangi42.polished-map-plusplus": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Rangi42.tilemap-studio": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.RodZill4.Material-Maker": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.Soundux": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "io.github.Sunderland93.sway-input-config": {
+        "finish-args-unnecessary-xdg-config-sway-rw-access": "Required to access Sway configuration on host"
+    },
+    "io.github.TTimo.GtkRadiant": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.TeamWheelWizard.WheelWizard": {
+        "finish-args-unnecessary-xdg-config-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin config files (e.g. for graphics settings)",
+        "finish-args-unnecessary-xdg-data-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin Mii and game/mod data files",
+        "finish-args-flatpak-appdata-folder-access": "this program needs to be able to access the Dolphin Flatpak's config and data directories for configuration and Mii/mod management",
+        "finish-args-flatpak-spawn-access": "this program needs to be able to run host commands as specified in the manifest's wrapper scripts to support Flatpak and native Dolphin installations"
+    },
+    "io.github.TransmissionRemoteGtk": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
+    },
+    "io.github.Youda008.DoomRunner": {
+        "finish-args-flatpak-spawn-access": "Needed to execute external game engines",
+        "finish-args-home-filesystem-access": "Needed to browse external game files and folders"
+    },
+    "io.github.accessory.minus_games_gui": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "io.github.achetagames.epic_asset_manager": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.adrienverge.PhotoCollage": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.aerocyber.sitemarker": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.aganzha.Stage": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "io.github.aggalex.Wineglass": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.github.am2r_community_developers.AM2RLauncher": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.am2r_community_developers.Atomic": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.amit9838.mousam": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.andreibachim.shortcut": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.antimicrox.antimicrox": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.bcpierce00.unison": {
+        "finish-args-flatpak-appdata-folder-access": "Unison must be able to sync all the user's data or config files",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.github.benini.scid": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.benjamimgois.goverlay": {
+        "finish-args-unnecessary-xdg-config-MangoHud-rw-access": "Needed for reading MangoHud config files",
+        "finish-args-unnecessary-xdg-config-vkBasalt-rw-access": "Needed for reading vkBasalt config files"
+    },
+    "io.github.betaflight.BetaflightConfigurator": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.bkbilly.lnxlink": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-systemd1-system-talk-name": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.bothlab.pomidaq": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.brunoherbelin.Vimix": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.btpf.alexandria": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.cboxdoerfer.FSearch": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.ciromattia.kcc": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.cleomenezesjr.aurea": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.cloose.CuteMarkEd": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
+    "io.github.coccinelle.coccinelle": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.congard.qnvsm": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
+    "io.github.cosmic_utils.Examine": {
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+    },
+    "io.github.ctlcltd.e2se": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.cudatext.CudaText-Qt": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.d0ksan8.zen-app-manager": {
+        "finish-args-unnecessary-xdg-config-autostart-rw-access": "Startup manager needs direct access to manage autostart entries"
+    },
+    "io.github.dagargo.Elektroid": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.daviddesimone.opencloudsaves": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "io.github.dbchoco.Salawat": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.debasish_patra_1987.linuxthemestore": {
+        "finish-args-dconf-talk-name": "needed to access host dconf configuration for modifying themes"
+    },
+    "io.github.dgsasha.Remembrance": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.dida_code.OpstaKultura": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.diegoivan.pdf_metadata_editor": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.diegoivanme.flowtime": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.diegopvlk.Dosage": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.dosbox-staging": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.dummerle.rare": {
+        "finish-args-flatpak-spawn-access": "Required to run Steam Linux Runtime based or host-native Steam compatibility tools (SteamRT/Proton) on the host",
+        "finish-args-home-filesystem-access": "needed for the default location to install games in",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "to create application shortcuts for games",
+        "finish-args-unnecessary-xdg-data-umu-ro-access": "to search for Steam compatibility tools managed by umu-launcher",
+        "finish-args-unnecessary-xdg-data-Steam-rw-access": "to search for Steam compatibility tools managed by Steam and create shortcuts in Steam's library"
+    },
+    "io.github.dvlv.boxbuddyrs": {
+        "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.dweymouth.supersonic": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-host-tmp-access": "Predates the linter rule"
     },
+    "io.github.dyegoaurelio.simple-wireplumber-gui": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-unnecessary-xdg-config-wireplumber-create-access": "this program creates config files in xdg-config/wireplumber"
+    },
+    "io.github.dzheremi2.lexi": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.dzheremi2.lrcmake-gtk": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.efogdev.mpris-timer": {
+        "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Predates the linter rule",
+        "finish-args-own-name-org.kde.StatusNotifierItem-3-1": "Predates the linter rule"
+    },
+    "io.github.epasveer.seer": {
+        "finish-args-flatpak-spawn-access": "Seer needs to launch the gdb binary that is on the host system.",
+        "finish-args-host-filesystem-access": "Seer needs to access the executable being debugged on the host system. Plus source files."
+    },
+    "io.github.erkin.ponysay": {
+        "finish-args-not-defined": "Terminal only, predates the linter"
+    },
+    "io.github.everestapi.Olympus": {
+        "finish-args-flatpak-spawn-access": "Required to be able to launch the modded Celeste game outside of the flatpak sandbox",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.ezQuake": {
+        "appid-code-hosting-too-few-components": "the app predates this linter rule"
+    },
+    "io.github.f3d_app.f3d": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.fabrialberio.pinapp": {
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "This program needs read-access to xdg-data/flatpak",
+        "finish-args-unnecessary-xdg-data-applications-rw-access": "This program needs read-write access to xdg-data/applications",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-autostart-filesystem-access": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.fastrizwaan.WineCharm": {
+        "finish-args-flatpak-appdata-folder-access": "Access the data directories of WineZGUI (same author) rw for to list WineZGUI scripts in WineCharm, and read-only access for wine, bottles, playonlinux, Phoenicis,  for copying runners and prefixes if/when user requires.",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.fastrizwaan.WineZGUI": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.fizzyizzy05.binary": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.flattool.Ignition": {
+        "finish-args-unnecessary-xdg-config-autostart-create-access": "This app's purpose is to manage autostart entries",
+        "finish-args-unnecessary-xdg-data-icons-ro-access": "Needed to be able to show app icons that are stored in this directory",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needed to be able to see the list of .desktop files associated with installed flatpaks, to be able to autostart them",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Needed to be able to see the list of .desktop files for user-installed applications, to be able to autostart them",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule"
+    },
+    "io.github.flattool.Warehouse": {
+        "finish-args-flatpak-spawn-access": "Required to manage Flatpaks on the host",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule"
+    },
+    "io.github.foldynl.QLog": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.secrets": "Predates the linter rule"
+    },
+    "io.github.fralonra.PpdEditor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.fralonra.WgShadertoy": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.garglk.Gargoyle": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.georgewoodall82.jsymphonic": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "io.github.gerryferdinandus.bittorrent-tracker-editor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.giantpinkrobots.bootqt": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.giantpinkrobots.flatsweep": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule"
+    },
+    "io.github.giantpinkrobots.varia": {
+        "finish-args-autostart-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule",
+        "finish-args-own-name-io.github.giantpinkrobots.varia-tray": "Predates the linter rule"
+    },
+    "io.github.gopher64.gopher64": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "io.github.gtkwave.GTKWave": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.guillaumechereau.Goxel": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
+    "io.github.hakuneko.HakuNeko": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.hedge_dev.hedgemodmanager": {
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
     "io.github.hermitdemschoenenleben.linien": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.github.ihhub.Fheroes2": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "io.github.ilya_zlobintsev.LACT": {
+        "finish-args-flatpak-spawn-access": "Required to set up the host service for GPU control."
+    },
+    "io.github.insilmaril.vym": {
+        "finish-args-own-name-org.insilmaril.vym-2": "Predates the linter rule"
+    },
+    "io.github.iptux_src.iptux": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.itprojects.MasVisGtk": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.ja2_stracciatella.JA2-Stracciatella": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
@@ -3331,389 +2903,63 @@
     "io.github.janbar.noson": {
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
-    "io.github.maddecoder.Classic-RBDOOM-3-BFG": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    "io.github.java_decompiler.jd-gui": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "io.github.pd_l2ork.Pd_L2Ork": {
+    "io.github.jchempaint.JChemPaint": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.rinigus.OSMScoutServer": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
+    "io.github.jean28518.Linux-Assistant": {
+        "finish-args-flatpak-spawn-access": "Required to get information about the os and execute host commands e.g. like the package managers",
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "io.github.slgobinath.SafeEyes": {
+    "io.github.jeffshee.Hidamari": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
-    "io.github.trigg.discover_overlay": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.github.ungoogled_software.ungoogled_chromium": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-dconf-talk-name": "Access host dconf for proxy resolution",
-        "finish-args-direct-dconf-path": "Access host dconf for proxy resolution",
-        "finish-args-host-tmp-access": "Access host tmp for MPRIS media cover art",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "io.itch.doctorm64.skippybot": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.itch.itch": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"
-    },
-    "io.jamulus.Jamulus": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.kinvolk.Headlamp": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.liri.Text": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+    "io.github.jliljebl.Flowblade": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "io.mpv.Mpv": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "module-x264-checker-tracks-commits": "Tracks stable branch commits, doesn't have releases",
-        "module-luajit-checker-tracks-commits": "Tracks stable branch commits, doesn't have releases",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
+    "io.github.jmberesford.Retrom": {
+        "finish-args-flatpak-spawn-access": "the app is a launcher for other arbitrary applications configured by the user and requires the ability to spawn external processes on the host",
+        "finish-args-home-filesystem-access": "many users place/install games and portable emulators/applications that Retrom must manage in arbitrary locations in the home directory"
+    },
+    "io.github.jonmagon.kdiskmark": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.jorchube.monitorets": {
         "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
-    "io.qt.QtCreator": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
+    "io.github.kalaksi.Lightkeeper": {
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
-    "io.typora.Typora": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
+    "io.github.kolunmi.Bazaar": {
+        "finish-args-flatpak-spawn-access": "Runs host binaries in order to successfully install and launch apps",
+        "finish-args-flatpak-system-folder-access": "Needs access to system-wide flatpak installation so that it can manage them",
+        "finish-args-flatpak-system-talk-name": "Talks to the system-wide flatpak dbus address in order to query existence of flatpaks and send installation commands to it",
+        "finish-args-flatpak-appdata-folder-access": "Needs access to user data of other apps so that it can remove leftover data"
     },
-    "net.displaycal.DisplayCAL": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    "io.github.kotatogram": {
+        "appid-code-hosting-too-few-components": "the app predates this linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "external-gitmodule-url-found": "Predates the linter rule",
+        "module-tg_owt-checker-tracks-commits": "Manually updated, grandfathered"
     },
-    "net.hovancik.Stretchly": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "net.mediaarea.BWFMetaEdit": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.mediaarea.MediaInfo": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "net.meshlab.MeshLab": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.mullvad.MullvadBrowser": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.mozilla.mullvadbrowser": "Predates the linter rule"
-    },
-    "net.pioneerspacesim.Pioneer": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "net.rpdev.OpenTodoList": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.sf.nootka": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.sourceforge.Lifeograph": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.sourceforge.dmidiplayer": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.sourceforge.kmetronome": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.sourceforge.kmidimon": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.unvanquished.Unvanquished": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "net.wz2100.wz2100": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "nl.openoffice.bluefish": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "one.ablaze.floorp": {
-        "finish-args-own-name-wildcard-org.mozilla.floorp": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "Needed for manually creating application .desktop files for Floorp's Web Apps feature",
-        "finish-args-unnecessary-xdg-data-icons-create-access": "Needed as Floorp's Web Apps feature downloads and installs icons for each website that the user adds",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "Needed for Breeze, etc. to use their colour scheme - upstream Firefox permission"
-    },
-    "org.bunkus.mkvtoolnix-gui": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.claws_mail.Claws-Mail": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.dust3d.dust3d": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.eu.encom.spectral": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.fdroid.Repomaker": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.ferdium.Ferdium": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+    "io.github.kukuruzka165.materialgram": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "external-gitmodule-url-found": "Predates the linter rule",
+        "module-tg_owt-checker-tracks-commits": "Manually updated, grandfathered",
         "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
-    "org.flameshot.Flameshot": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.freedesktop.Piper": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.freedesktop.Tuhi": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.tuhi1": "Predates the linter rule"
-    },
-    "org.freedesktop.adriconf": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+    "io.github.labbots.NiimPrintX": {
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "org.freeplane.App": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
+    "io.github.lawstorant.boxflat": {
+        "finish-args-flatpak-spawn-access": "Required for automatic per-game preset application based on process name"
     },
-    "org.frescobaldi.Frescobaldi": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.geeqie.Geeqie": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Genius": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-own-name-org.gnome.genius": "Predates the linter rule"
-    },
-    "org.gnome.Keysign": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.OCRFeeder": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-freedesktop-dbus-system-talk-name": "Predates the linter rule",
-        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Tau": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.hedgewars.Hedgewars": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.jaspstats.JASP": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.karapulse.Karapulse": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.skrooge": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.mamedev.MAME": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.mobsya.ThymioSuite": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.musicbrainz.Picard": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.olivevideoeditor.Olive": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.onlyoffice.desktopeditors": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.openkj.OpenKJ": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.openmsx.openMSX": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.pjbroad.EternallandsClient": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.polymc.PolyMC": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.ppsspp.PPSSPP": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.robocode.Robocode": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.scummvm.ScummVM": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.signal.Signal": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.speedcrunch.SpeedCrunch": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.synfig.SynfigStudio": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.tropy.Tropy": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.tug.texworks": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.tuxemon.Tuxemon": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.tuxpaint.Tuxpaint": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.vinegarhq.Vinegar": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.winehq.Wine": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "toplevel-unnecessary-branch": "Wine uses a custom branch following runtime branch for historical reasons"
-    },
-    "page.codeberg.lazyt.ubpm": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "party.supertux.supertuxparty": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "ru.linux_gaming.PortProton": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "sa.sy.bluerecorder": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "space.fips.Fips": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "studio.kx.carla": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "tv.plex.PlexHTPC": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "ua.org.brezblock.q4wine": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "uk.jnthn.backgammony": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "uk.me.doof.Lander": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "website.i2pd.i2pd": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "xyz.hyperplay.HyperPlay": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.splashmapper.Splash": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.stuerz.BilligSweeper": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.enpass.Enpass": {
-        "flathub-json-automerge-enabled": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.secrets": "Predates the linter rule"
-    },
-    "io.frama.tractor.carburetor": {
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
-    },
-    "net.christianbeier.Gromit-MPX": {
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule"
-    },
-    "ru.yandex.Browser": {
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.vikdevelop.SaveDesktop": {
-        "finish-args-dconf-talk-name": "Predates the linter rule",
-        "finish-args-direct-dconf-path": "Predates the linter rule",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
-        "finish-args-legacy-icon-folder-permission": "Specifically meant to save desktop settings",
-        "finish-args-legacy-font-folder-permission": "Specifically meant to save desktop settings",
-        "finish-args-incorrect-theme-folder-permission": "Specifically meant to save desktop settings",
-        "finish-args-full-home-local-share-access": "Predates the linter rule",
-        "finish-args-full-home-config-access": "Predates the linter rule"
-    },
-    "dev.bsnes.bsnes": {
-        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "needs access to xdg-config/gtk-3.0 for theming, does not support portals",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.edfloreshz.Tasks": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
-    },
-    "dev.mariinkys.Oboete": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
-    },
-    "dev.mariinkys.StarryDex": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
-    },
-    "dev.lunarsrl.NovaMusic": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
-    },
-    "org.gnome.Tomboy": {
-        "finish-args-freedesktop-dbus-system-talk-name": "Predates the linter rule"
-    },
-    "com.codemouse92.timecard": {
-        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "moe.tundra.Tundra": {
-        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule"
-    },
-    "org.dupot.easyflatpak": {
-        "finish-args-flatpak-spawn-access": "Required to install then override some flatpak application (for example asking game folder for steam or lutris)"
-    },
-    "org.qownnotes.QOwnNotes": {
-        "flathub-json-automerge-enabled": "Verified application",
+    "io.github.limads.Queries": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.limo_app.limo": {
@@ -3721,98 +2967,76 @@
         "finish-args-flatpak-appdata-folder-access": "Predates the linter rule. Required for accessing apps installed to the default directory by Flatpak Steam",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.wivrn.wivrn": {
-        "finish-args-unnecessary-xdg-config-openvr-create-access": "Required to set the current OpenVR runtime",
-        "finish-args-unnecessary-xdg-config-openxr-create-access": "Required to set the current OpenXR runtime",
-        "finish-args-flatpak-spawn-access": "Required to launch games on the host",
-        "finish-args-flatpak-appdata-folder-access": "Required to list games in Steam flatpak",
-        "finish-args-unnecessary-xdg-data-Steam-ro-access": "Required to list games in system Steam",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to list .desktop files on the host",
-        "finish-args-login1-system-talk-name": "Predates the linter rule",
-        "finish-args-own-name-io.github.wivrn.Server": "Predates the linter rule"
+    "io.github.loot.loot": {
+        "finish-args-unnecessary-xdg-config-heroic-ro-access": "Needed to detect games installed through Heroic Games Launcher.",
+        "finish-args-unnecessary-xdg-config-openmw-rw-access": "Needed to detect and make changes to OpenMW when it is installed as a distribution package.",
+        "finish-args-unnecessary-xdg-data-openmw-ro-access": "Needed to read OpenMW data when it is installed as a distribution package.",
+        "finish-args-unnecessary-xdg-data-Steam-ro-access": "Needed to detect and make changes to games installed through Steam.",
+        "finish-args-unnecessary-xdg-data-Steam-rw-access": "Needed to detect and make changes to games installed through Steam.",
+        "finish-args-flatpak-appdata-folder-access": "Needed to detect and make changes to games installed through Steam and Heroic Games Launcher.",
+        "finish-args-flatpak-system-folder-access": "Needed to read the OpenMW install folder when it is installed as a system Flatpak.",
+        "finish-args-flatpak-user-folder-access": "Needed to read the OpenMW install folder when it is installed as a user Flatpak."
     },
-    "org.freedesktop.LinuxAudio.BaseExtension": {
-        "finish-args-not-defined": "This provides an extension point only",
-        "toplevel-no-command": "This provides an extension point only",
-        "appstream-metainfo-missing": "This provides an extension point only"
+    "io.github.lruzicka.Needly": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "surf.deckr.deckr": {
-        "appid-url-not-reachable": "Request is returning 403, https://github.com/flathub/flathub/pull/5529#issuecomment-2325455509"
-    },
-    "com.vysp3r.ProtonPlus": {
-        "finish-args-flatpak-spawn-access": "required to install and manage compatibility-runtimes on the host",
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+    "io.github.ltiber.Pwall": {
         "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "dev.edfloreshz.CosmicTweaks": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write to system configuration files"
+    "io.github.maddecoder.Classic-RBDOOM-3-BFG": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
-    "fr.sgued.bodev": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write to system configuration files"
+    "io.github.manisandro.gImageReader": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.gnome.gimagereader": "Predates the linter rule"
     },
-    "com.jwestall.Forecast": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read the system theme and listen for config changes in the host"
+    "io.github.marco_calautti.DeltaPatcher": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "dev.edfloreshz.Calculator": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    "io.github.martchus.syncthingtray": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-systemd1-talk-name": "Predates the linter rule"
     },
-    "com.francescogaglione.chronos": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    "io.github.martinrotter.textosaurus": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "com.francescogaglione.cosmicmoney": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    "io.github.maurycyliebner.enve": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.cosmic_utils.Examine": {
-        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+    "io.github.mfat.sshpilot": {
+        "finish-args-has-socket-ssh-auth": "Needs host SSH agent for seamless key-based SSH; app implements secure retrieval of secrets from keychain and adding them to ssh-agent for use.",
+        "finish-args-ssh-filesystem-access": "Just read-only access to load user's existing keypairs.",
+        "finish-args-flatpak-spawn-access": "The app is basically a terminal emulator with extra options for SSH. Users expect host shell access weh opening a local terminal tab."
     },
-    "io.github.pixeldoted.cosmic-ext-color-picker": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    "io.github.mgerhardy.vengi.voxedit": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "org.freedesktop.Platform.ClInfo": {
+    "io.github.mhogomchungu.sirikali": {
+        "finish-args-flatpak-spawn-access": "this app is a front end to gocryptfs,securefs and cryfs. These tools do folder based encryption and they depend on fusermount located at /bin to mount and unmount their file systems"
+    },
+    "io.github.microgamercz.piki": {
+        "finish-args-plasmashell-talk-name": "Predates the linter rule"
+    },
+    "io.github.mightycreak.Diffuse": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.mihnea_radulescu.imagefanreloaded": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.mki1967.mki3dgame": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
-    "org.freedesktop.Platform.GlxInfo": {
+    "io.github.mmstick.FontFinder": {
+        "finish-args-unnecessary-xdg-data-fonts-create-access": "This program is designed to store font files in the font directory",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
         "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.freedesktop.Platform.VaInfo": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.freedesktop.Platform.VdpauInfo": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "org.freedesktop.Platform.VulkanInfo": {
-        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
-    },
-    "io.github.lawstorant.boxflat": {
-        "finish-args-flatpak-spawn-access": "Required for automatic per-game preset application based on process name"
-    },
-    "menu.kando.Kando": {
-        "finish-args-flatpak-spawn-access": "Required because Kando is an app-launcher",
-        "finish-args-kwin-talk-name": "Required to talk to a KWin script for getting the focused window name"
-    },
-    "io.github.flattool.Ignition": {
-        "finish-args-unnecessary-xdg-config-autostart-create-access": "This app's purpose is to manage autostart entries",
-        "finish-args-unnecessary-xdg-data-icons-ro-access": "Needed to be able to show app icons that are stored in this directory",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needed to be able to see the list of .desktop files associated with installed flatpaks, to be able to autostart them",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "Needed to be able to see the list of .desktop files for user-installed applications, to be able to autostart them",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule"
-    },
-    "net.imaginaryinfinity.Squiid": {
-        "finish-args-not-defined": "Is a command line application"
-    },
-    "org.freedesktop.Sdk.Extension.dmd": {
-        "module-dmd-checker-tracks-commits": "Uses tag, grandfathered"
-    },
-    "org.gnome.Boxes.Extension.OsinfoDb": {
-        "module-osinfo-db-checker-tracks-commits": "Uses tag, grandfathered"
-    },
-    "org.DolphinEmu.dolphin-emu": {
-        "module-dolphin-emu-checker-tracks-commits": "Uses beta channel",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.itch.amcsquad.amcsquad": {
-        "module-amc-data-checker-tracks-commits": "Uses tag"
     },
     "io.github.moonlight_mod.moonlight-installer": {
         "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needed to patch Flatpak installations of Discord",
@@ -3823,1283 +3047,13 @@
         "finish-args-unnecessary-xdg-data-DiscordDevelopment-rw-access": "Needed to patch Discord Development",
         "finish-args-unnecessary-xdg-config-moonlight-mod-create-access": "Patches are stored here, needs to be accessible from all patched Discord instances"
     },
-    "app.freelens.Freelens": {
-        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    "io.github.mpc_qt.mpc-qt": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "The app supports both X11 and Wayland through a Tweaks setting"
     },
-    "org.qbittorrent.qBittorrent": {
-        "module-libtorrent-checker-tracks-commits": "Tracks stable, low maintenace branch commits",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.chowdsp.BYOD": {
-        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.BYOD": "Predates the linter rule"
-    },
-    "com.thewavewarden.Odin2": {
-        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Odin2": "Predates the linter rule"
-    },
-    "de.bforartists.Bforartists": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "net.sonobus.SonoBus": {
-        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.SonoBus": "Predates the linter rule"
-    },
-    "org.audacityteam.Audacity": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.guitarix.Guitarix": {
-        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Guitarix": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.stochas.Stochas": {
-        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Stochas": "Predates the linter rule"
-    },
-    "org.surge_synth_team.surge-xt": {
-        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Surge-XT": "Predates the linter rule"
-    },
-    "org.tenacityaudio.Tenacity": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "dev.heppen.webapps": {
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Access for reading installed browsers",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "Access for writing desktop files for web apps",
-        "finish-args-unnecessary-xdg-data-icons-rw-access": "Access for writing icons into xdg-data/icons/QuickWebApps directory for created webapps",
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "For COSMIC desktop environment",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
-    },
-    "com.valvesoftware.Steam.CompatibilityTool.Proton-GE": {
-        "manifest-file-is-symlink": "Predates the linter rule"
-    },
-    "com.arviceblot.eso-addon-manager": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "com.eduke32.EDuke32": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "com.outerwildsmods.owmods_gui": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "dev.qwery.AddWater": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "gg.minion.Minion": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.blockloader.BlockLoader": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.edcd.EDMarketConnector": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.github.Foldex.AdwSteamGtk": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.github.accessory.minus_games_gui": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.github.fastrizwaan.WineZGUI": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.giantpinkrobots.flatsweep": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule"
-    },
-    "io.github.santiagocezar.maniatic-launcher": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.github.theforceengine.tfe": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "io.kopia.KopiaUI": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.bleachbit.BleachBit": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.gnome.Bleachbit": "Predates the linter rule"
-    },
-    "org.gnome.DejaDup": {
-        "finish-args-flatpak-appdata-folder-access": "Users would expect that a full home backup would include flatpak application configuration and data",
-        "finish-args-flatpak-spawn-access": "Required to spawn fusermount, mounting the user's backup via FUSE",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.gnome.baobab": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.sonic3air.Sonic3AIR": {
-        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
-    },
-    "org.freedesktop.appstream-glib": {
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.freedesktop.appstream.cli": {
-        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
-        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.ktechpit.orion": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "com.lablicate.OpenChrom": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "com.qq.QQ": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.zettlr.Zettlr": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "io.github.bkbilly.lnxlink": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-systemd1-system-talk-name": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.brunoherbelin.Vimix": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.coccinelle.coccinelle": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.nroduit.Weasis": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.quodlibet.ExFalso": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-plasmashell-talk-name": "Predates the linter rule"
-    },
-    "io.github.quodlibet.QuodLibet": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-plasmashell-talk-name": "Predates the linter rule",
-        "finish-args-own-name-org.mpris.quodlibet": "Predates the linter rule",
-        "finish-args-own-name-org.gnome.UPnP.MediaServer2.QuodLibet": "Predates the linter rule"
-    },
-    "io.github.retgal.Dayon": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.ripose_jp.Memento": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.tfuxu.Halftone": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "io.neovim.nvim": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.webtorrent.WebTorrent": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "net.sourceforge.paulstretch": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "net.xmind.XMind": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.cloudcompare.CloudCompare": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.denemo.Denemo": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.expresslrs.ExpressLRSConfigurator": {
-        "finish-args-host-tmp-access": "Predates the linter rule"
-    },
-    "org.gnupg.GPA": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
-    },
-    "org.kicad.KiCad": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.ksnip.ksnip": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.racket_lang.Racket": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "org.sil.Bloom": {
-        "finish-args-host-tmp-access": "Predates the linter rule",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.protonvpn.www": {
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule",
-        "finish-args-own-name-proton.vpn.app.gtk": "Predates the linter rule"
-    },
-    "eu.betterbird.Betterbird": {
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.mozilla.betterbird": "Predates the linter rule"
-    },
-    "io.github.plrigaux.sysd-manager": {
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-systemd1-talk-name": "Predates the linter rule",
-        "finish-args-systemd1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.rafaelfassi.QLogExplorer": {
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "it.cuteworks.pacmanlogviewer": {
-        "finish-args-host-var-access": "Predates the linter rule"
-    },
-    "org.gnome.Logs": {
-        "finish-args-host-var-access": "Predates the linter rule"
-    },
-    "org.linux_hardware.hw-probe": {
-        "finish-args-host-var-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.vertcoin.vertcoin-qt": {
-        "finish-args-host-var-access": "Predates the linter rule"
-    },
-    "sh.loft.devpod": {
-        "finish-args-flatpak-spawn-access": "Required for host shell access",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.github.piotrek_k._2dTaskBoard": {
-        "appid-url-not-reachable": "Repo is 2dTaskBoard but appstream expects leading underscore, manually verified"
-    },
-    "page.codeberg.JakobDev.jdPermissionStoreEdit": {
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needs acccess to xdg-data/flatpak/db"
-    },
-    "io.github.ilya_zlobintsev.LACT": {
-        "finish-args-flatpak-spawn-access": "Required to set up the host service for GPU control."
-    },
-    "page.codeberg.JakobDev.jdSystemMonitor": {
-        "finish-args-flatpak-spawn-access": "Run the Daemon outside the Flatpak"
-    },
-    "dev.geopjr.Turntable": {
-        "finish-args-freedesktop-dbus-talk-name": "Required to gather and update the list of all available MPRIS clients",
-        "finish-args-flatpak-appdata-folder-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",
-        "finish-args-host-var-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",
-        "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files and icons for listing MPRIS clients",
-        "finish-args-flatpak-system-folder-access": "Required to read .desktop files and icons for listing MPRIS clients",
-        "finish-args-full-home-cache-access": "Required to read the local MPRIS artUrl files from some MPRIS clients",
-        "finish-args-host-tmp-access": "Required to read the local MPRIS artUrl files from some MPRIS clients"
-    },
-    "org.siril.Siril": {
-        "finish-args-flatpak-spawn-access": "required to interact with third-party applications like astrometry.net for plate solving and other astronomical image processing workflows",
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.radiolamp.mangojuice": {
-        "finish-args-unnecessary-xdg-config-MangoHud-create-access": "Access shared MangoHud configuration files",
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.allotropia.ZetaOffice": {
-        "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "This was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/111> 'GTK bookmarks do not appear in the flatpak version of LibreOffice' in the org.libreoffice.LibreOffice app from which this app derives",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "This was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/136> 'fontconfig user configuration' in the org.libreoffice.LibreOffice app from which this app derives",
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-de.allotropia.ZetaOfficeIpc0": "Predates the linter rule"
-    },
-    "io.github.DenysMb.Kontainer": {
-        "finish-args-flatpak-spawn-access": "Requires use of Distrobox on the host",
-        "finish-args-desktopfile-filesystem-access": "Needed to list exported apps from distroboxes"
-    },
-    "io.github.bcpierce00.unison": {
-        "finish-args-flatpak-appdata-folder-access": "Unison must be able to sync all the user's data or config files",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.rioterm.Rio": {
-        "finish-args-flatpak-spawn-access": "required to spawn the user's shell and other commands on the host system; it's the primary purpose of a terminal emulator"
-    },
-    "dev.vencord.Vesktop": {
-        "finish-args-contains-both-x11-and-wayland": "Running through native Wayland instead of X11 causes issues for a considerable number of users, but Wayland access is still needed for pipewire screen capturing"
-    },
-    "best.ellie.StartupConfiguration": {
-        "finish-args-unnecessary-xdg-config-autostart-create-access": "This app requires access to the hosts' ~/.config/autostart directory in create mode in order to manage applications launched on startup.",
-        "finish-args-flatpak-system-folder-access": "This app requires read-only access to the hosts' /var/lib/flatpak/exports/share/{applications,icons} directories in order to allow users to add them to the applications launched on startup.",
-        "finish-args-flatpak-user-folder-access": "This app requires read-only access to the hosts' ~/.local/share/flatpak/exports/share/{applications,icons} directories in order to allow users to add them to the applications launched on startup.",
-        "finish-args-host-var-access": "This app requires read-only access to the hosts' /var/lib/snapd/desktop/applications directory in order to allow users to add snaps to the applications launched on startup.",
-        "finish-args-autostart-filesystem-access": "Predates the linter rule",
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "app.katvan.Katvan": {
-        "finish-args-unnecessary-xdg-data-typst-ro-access": "Well known common location of the user's Typst packages in the @local namespace"
-    },
-    "com.stremio.Stremio": {
-        "finish-args-contains-both-x11-and-wayland": "The window is able to be create under wayland but this app uses CEF (Chromium Embedded Framework) which requires acccess to X11"
-    },
-    "io.github.debasish_patra_1987.linuxthemestore": {
-        "finish-args-dconf-talk-name": "needed to access host dconf configuration for modifying themes"
-    },
-    "io.github.Faugus.faugus-launcher": {
-        "finish-args-contains-both-x11-and-wayland": "Without socket=X11 Winetricks doesn't work on Wayland and without socket=wayland the Wine Wayland driver doesn't work.",
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Required for MangoHud to detect the settings file."
-    },
-    "app.getclipboard.Clipboard": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "app.pianocheetah.pianocheetah": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.beavernotes.beavernotes": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.gtk.vfs": "Predates the linter rule"
-    },
-    "com.bitwig.BitwigStudio": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.blitterstudio.amiberry": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.cinecred.cinecred": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.darhon.syncbackup": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.haysell.pos": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.interversehq.qView": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.jetbrains.GoLand": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.jetbrains.RustRover": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.kristianduske.TrenchBroom": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.neatdecisions.Detwinner": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.nextcloud.desktopclient.nextcloud": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-com.nextcloudgmbh.Nextcloud": "Predates the linter rule"
-    },
-    "com.nitrokey.nitrokey-app": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.nolimitconnect.NoLimitConnect": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.okta.developer.CLI": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.parallax.PropellerIDE": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.playonlinux.PlayOnLinux4": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.popcornfx.PopcornFXEditor": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.pypyrev.linuxdcpp": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.rtosta.zapzap": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.sayonara_player.Sayonara": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.sigmyne.crush": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.strlen.TreeSheets": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.transmissionbt.Transmission": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.vba_m.visualboyadvance-m": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.vesc_project.VescTool": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.vzhd1701.gridplayer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "com.wonderlandengine.editor": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.akaflieg_freiburg.enroute": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.haeckerfelix.Fragments": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.lernsoftware_filius.Filius": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.philippun1.turtle": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "de.renew.Renew": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "de.rwth_aachen.ient.YUView": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "dev.ares.ares": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "dev.gbstudio.gb-studio": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "dev.pulsar_edit.Pulsar": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "eu.scarpetta.PDFMixTool": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "fi.mooc.tmc.tmc-cli-rust": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "fr.free.qccrypt.Qccrypt": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "fr.handbrake.ghb": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "fr.natron.Natron": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "fr.nytuo.cosmiccomics": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "info.puredata.Pd-extended": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "info.smplayer.SMPlayer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.JakubMelka.Pdf4qt": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Rangi42.polished-map": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Rangi42.polished-map-plusplus": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Rangi42.tilemap-studio": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.TTimo.GtkRadiant": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.andreibachim.shortcut": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.cboxdoerfer.FSearch": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.ctlcltd.e2se": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.daviddesimone.opencloudsaves": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.dzheremi2.lexi": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.dzheremi2.lrcmake-gtk": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.fralonra.WgShadertoy": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.georgewoodall82.jsymphonic": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.java_decompiler.jd-gui": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.jonmagon.kdiskmark": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.labbots.NiimPrintX": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.ltiber.Pwall": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.marco_calautti.DeltaPatcher": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.onionware_github.onionmedia": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-talk-name": "Predates the linter rule"
-    },
-    "io.github.peazip.PeaZip": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.pieterdd.RcloneShuttle": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.shundhammer.qdirstat": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.sithlord48.blackchocobo": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.sxyazi.yazi": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.xyproto.zsnes": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.gitlab.dev_nis.one-click-backup": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.greenfire.Greenery": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.ossia.score": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.posidon.Paper": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.qt.Linguist": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "io.qt.qtdesignstudio": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "la.ogri.strongbox": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "lol.janjic.Splitcat": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "me.kozec.syncthingtk": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "media.emby.EmbyServer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "moe.clover.mm3d": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.blumia.pineapple-pictures": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.darkradiant.DarkRadiant": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.giuspen.cherrytree": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.jenyay.Outwiker": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.natesales.Aviator": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "net.purrdata.PurrData": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.avidemux.Avidemux": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.beeref.BeeRef": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.bionus.Grabber": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.blender.Blender": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.bluej.BlueJ": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.buhocms.BuhoCMS": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.caione.GScope": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.cvfosammmm.Setzer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.d3cod3.Mosaic": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.darktable.Darktable": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.darktable.service": "Predates the linter rule"
-    },
-    "org.emptyflow.ArdorQuery": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.filezillaproject.Filezilla": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.flatpak.qtdemo": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.flozz.yoga-image-optimizer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.fontforge.FontForge": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.freac.freac": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.freedesktop.appstream.generator": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.geany.Geany": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.getzola.zola": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.GHex": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Glade": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.gitg": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.gnome.gitlab.somas.Apostrophe": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnucash.GnuCash": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.greenfoot.Greenfoot": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.gtkhash.gtkhash": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.jreleaser.cli": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.krita": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.subtitlecomposer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.libretro.RetroArch": {
-        "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-talk-name": "Predates the linter rule"
-    },
-    "org.libvips.nip4": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.mattbas.Glaxnimate": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.nongnu.gsequencer.gsequencer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.pencil2d.Pencil2D": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.photoqt.PhotoQt": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.pitivi.Pitivi": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.previewqt.PreviewQt": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.qelectrotech.QElectroTech": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.scantailor.ScanTailor": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.scintilla.SciTE": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.shotcut.Shotcut": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.sil.dictionary-app-builder": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.sil.keyboard-app-builder": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.sil.reading-app-builder": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.sil.scripture-app-builder": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.skytemple.SkyTemple": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.squey.Squey": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.swi_prolog.swipl": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.tabos.roger": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.trelby.Trelby": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.upbge.UPBGE": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.videolan.VLC": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.viking.Viking": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.xfce.mousepad": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "org.zaproxy.ZAP": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "re.sonny.Commit": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "se.cendio.tlclient": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "space.nouspiro.tenmon": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "studio.assetmanager.ams": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.rust4diva.Rust4Diva": {
+    "io.github.mpobaschnig.Vaults": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-host-filesystem-access": "Predates the linter rule"
-    },
-    "app.authpass.AuthPass": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "app.bluebubbles.BlueBubbles": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "app.cantara.Cantara": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "app.midterm.MidtermDesktop": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "app.opencomic.OpenComic": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "app.riftshare.RiftShare": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "app.vup.Vup": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ar.com.pilas_engine.App": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ar.xjuan.Cambalache": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "au.edu.uq.esys.escript": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "br.com.wiselabs.simplexity": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "br.eng.silas.qpdftools": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "br.gov.cti.invesalius": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ca.edestcroix.Recordbox": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ca.littlesvr.asunder": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ca.uwaterloo.Raven": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "cat.xtec.clic.JClic": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "cc.arduino.IDE2": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ch.theologeek.Manuskript": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "chat.iamb.iamb": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "chat.simplex.simplex": {
-        "finish-args-home-filesystem-access": "Allows the users to send/save files from/to their home directory"
-    },
-    "cn.apipost.apipost": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "cn.navclub.ldbfx": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "cn.ottercorp.xivlaunchercn": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "codes.loers.Karlender": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.abisource.AbiWord": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.bambulab.BambuStudio": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.belmoussaoui.snowglobe": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.qemu": "Predates the linter rule"
-    },
-    "com.bespokesynth.BespokeSynth": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.bestaticpy.bestatic": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.brosix.Brosix": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.cburch.Logisim": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.cerebralnomad.recipescribe": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.diy_fever.DIYLayoutCreator": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.dosbox_x.DOSBox-X": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.expidusos.file_manager": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.georgefb.mangareader": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.giadamusic.Giada": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.gigitux.youp": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.gitfiend.GitFiend": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.gluonhq.SceneBuilder": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.hoptodesk.HopToDesk": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.hostbuf.FinalShell": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.icanblink.blink": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.inform7.IDE": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.inklestudios.Inky": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.itextpdf.RUPS": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.itopia.client": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.jaquadro.NBTExplorer": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.jianguoyun.Nutstore": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.jpexs.decompiler.flash": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.librumreader.librum": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.lynnmichaelmartin.TimeTracker": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.mikrotik.WinBox": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.mongodb.Compass": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.mtkennerly.madamiru": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.neoutils.NeoRegex": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.nickgirga.webready": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.ntrack.n-track": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.ReserveDevice1": "Predates the linter rule"
-    },
-    "com.one_ware.OneWare": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.openwall.John": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.orama_interactive.Pixelorama": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.pinegrow.Pinegrow": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.polyphone_soundfonts.polyphone": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.poweriso.PowerISO": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.reqable.Reqable": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.richwhitehouse.BigPEmu": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.rustdesk.RustDesk": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.scanoss.sbom-workbench": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sciactive.QuickDAV": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sigil_ebook.Sigil": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.simulide.simulide": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sireliah.Dragit": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sleepfiles.OSCAR": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.snes9x.Snes9x": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.st.STM32CubeMX": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.steamdeckrepo.manager": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sweethome3d.Sweethome3d": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.sweetscape.ZeroOneZeroEditor": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.thincast.client": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.tic80.TIC_80": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.toolstack.Folio": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.usebruno.Bruno": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.vicr123.thebeat": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.voxdsp.Borg": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.voxdsp.Borg0": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.voxdsp.VoxelPaint": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.voxdsp.VoxelPaintPro": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.wireframesketcher.WireframeSketcher": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.yacreader.YACReader": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.zerobrane.studio": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "cz.zeropage.Formiko": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.create3000.titania": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.danielnoethen.butt": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.desy.constellation": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.fabrik19.mos-Launcher": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.finnik.PassVault": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.flose.Kochbuch": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.hohnstaedt.xca": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.linuxguides.RechnungsAssistent": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.manuel_kehl.go-for-it": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.marlam.qv": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "de.nagstamon.nagstamon": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.bambosh.UnofficialHomestuckCollection": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.lukebriggs.pepys": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.mrquantumoff.mcmodpackmanager": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.dev_mrquantumoff_mcmodpackmanager.SingleInstance": "Predates the linter rule"
-    },
-    "dev.paullee.scraterpreter.Scrapec": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.restfox.Restfox": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "dev.tchx84.Portfolio": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.FileManager1": "Predates the linter rule"
-    },
-    "edu.stanford.protege": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "ee.ria.qdigidoc4": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "es.danirod.Cartero": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "eu.codepoems.xl-converter": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "fm.helio.Workstation": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "fm.reaper.Reaper": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "fr.dwightstudio.JArmEmu": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "fr.free.Homebank": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "fr.inria.corese.CoreseCommand": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "fr.inria.corese.CoreseGui": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "info.puredata.Pd": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.appflowy.AppFlowy": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-io.appflowy.appflowy": "Predates the linter rule"
-    },
-    "io.conduktor.Conduktor": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.dbeaver.DBeaverCommunity": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.frappe.books": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Adda0.Stardrop": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Cockatrice.cockatrice": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.DraqueT.PolyGlot": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.JaGoLi.ytdl_gui": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Omniaevo.mqtt5-explorer": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.Q1CHENL.fig": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.adrienverge.PhotoCollage": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.aganzha.Stage": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.github.am2r_community_developers.Atomic": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.antimicrox.antimicrox": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.benini.scid": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.benjamimgois.goverlay": {
-        "finish-args-unnecessary-xdg-config-MangoHud-rw-access": "Needed for reading MangoHud config files",
-        "finish-args-unnecessary-xdg-config-vkBasalt-rw-access": "Needed for reading vkBasalt config files"
-    },
-    "io.github.bothlab.pomidaq": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.ciromattia.kcc": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.cleomenezesjr.aurea": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.cudatext.CudaText-Qt": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.dagargo.Elektroid": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.f3d_app.f3d": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.foldynl.QLog": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.freedesktop.secrets": "Predates the linter rule"
-    },
-    "io.github.fralonra.PpdEditor": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.garglk.Gargoyle": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.gtkwave.GTKWave": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.hakuneko.HakuNeko": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.iptux_src.iptux": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.itprojects.MasVisGtk": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.jchempaint.JChemPaint": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.lruzicka.Needly": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.manisandro.gImageReader": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.gnome.gimagereader": "Predates the linter rule"
-    },
-    "io.github.martchus.syncthingtray": {
-        "finish-args-home-filesystem-access": "Predates the linter rule",
-        "finish-args-systemd1-talk-name": "Predates the linter rule"
-    },
-    "io.github.mgerhardy.vengi.voxedit": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.mrmyhuang.cbetar2": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5116,29 +3070,186 @@
     "io.github.narunlifescience.AlphaPlot": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.nate_xyz.Chromatic": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.nate_xyz.Conjure": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.nate_xyz.Resonance": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.nearinfinitybrowser.nearinfinity": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "io.github.nelson_lang.Nelson": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.github.nest_desktop.nest-desktop": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.nikelaz.CTLDash": {
+        "finish-args-systemd1-talk-name": "Needed to list, and control (start, stop, restart, enable, disable) systemd user services.",
+        "finish-args-systemd1-system-talk-name": "Needed to list and control (start, stop, restart, enable, disable) systemd system services.",
+        "finish-args-flatpak-spawn-access": "Needed to execute host commands (systemctl enable/disable via pkexec, and journalctl for service logs), as these operations require escaping the sandbox to interact with the host's systemd.",
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+    },
+    "io.github.nokse22.inspector": {
+        "finish-args-flatpak-spawn-access": "Needed to execute external commands to show informations about your computer",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.nokse22.teleprompter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.nokse22.ultimate-tic-tac-toe": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "io.github.noxworld_dev.OpenNox": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.nroduit.Weasis": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.nyre221.kiview": {
+        "finish-args-wildcard-kde-talk-name": "Required to send commands to the active dolphin window.",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.onionware_github.onionmedia": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-talk-name": "Predates the linter rule"
     },
     "io.github.opennumismat.open-numismat": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.orontee.Argos": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.github.pantheon_tweaks.pantheon-tweaks": {
+        "finish-args-flatpak-spawn-access": "Needed to get XDG_DATA_DIRS with flatpak-swapn to bridge host's GSettings.",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-legacy-icon-folder-permission": "DE tweak app",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.pd_l2ork.Pd_L2Ork": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.peazip.PeaZip": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "io.github.pemsley.coot": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.phastmike.tags": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.philipk.boilr": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required for showing which other Flatpaks are installed, so a shortcut can be added easly to Steam",
+        "finish-args-unnecessary-xdg-data-lutris-ro-access": "Required for reading the installed games in Lutris, so a shortcut can be added easly to Steam",
+        "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the shortcuts file in Steam, this is the purpose of BoilR",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
     },
     "io.github.picocrypt.Picocrypt": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.pieterdd.RcloneShuttle": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.piotrek_k._2dTaskBoard": {
+        "appid-url-not-reachable": "Repo is 2dTaskBoard but appstream expects leading underscore, manually verified"
+    },
+    "io.github.pixeldoted.cosmic-ext-color-picker": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    },
+    "io.github.plrigaux.sysd-manager": {
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-systemd1-talk-name": "Predates the linter rule",
+        "finish-args-systemd1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.pol_rivero.github-desktop-plus": {
+        "finish-args-has-socket-ssh-auth": "Needed to clone repositories using SSH.",
+        "finish-args-has-socket-gpg-agent": "Needed to sign commits with GPG.",
+        "finish-args-host-filesystem-access": "Needed to read and modify files in git repos outside of sandbox.",
+        "finish-args-flatpak-system-folder-access": "Needed to check which text editors the user has installed as flatpaks.",
+        "finish-args-flatpak-spawn-access": "Needed to spawn external text editors and terminals."
+    },
+    "io.github.prateekmedia.appimagepool": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.punesemu.puNES": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.pwr_solaar.solaar": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.qnapi": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.github.quodlibet.ExFalso": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-plasmashell-talk-name": "Predates the linter rule"
+    },
+    "io.github.quodlibet.QuodLibet": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-plasmashell-talk-name": "Predates the linter rule",
+        "finish-args-own-name-org.mpris.quodlibet": "Predates the linter rule",
+        "finish-args-own-name-org.gnome.UPnP.MediaServer2.QuodLibet": "Predates the linter rule"
+    },
+    "io.github.qwersyk.Newelle": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "io.github.ra3xdh.qucs_s": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.radiolamp.mangojuice": {
+        "finish-args-unnecessary-xdg-config-MangoHud-create-access": "Access shared MangoHud configuration files",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.rafaelfassi.QLogExplorer": {
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.randovania.Randovania": {
+        "finish-args-unnecessary-xdg-config-Ryujinx-rw-access": "required to export a randomizer to the host's Ryujinx settings",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "io.github.realmazharhussain.GdmSettings": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-config-monitors.xml-ro-access": "required for 'apply current display settings to GDM' feature"
+    },
+    "io.github.retgal.Dayon": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.rfrench3.scopebuddy-gui": {
+        "finish-args-unnecessary-xdg-config-scopebuddy-create-access": "This program needs to be able to create and modify xdg-config/scopebuddy/scb.conf (edit config of host Scopebuddy)"
+    },
     "io.github.riftr.intelpy": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.rimsort.RimSort": {
+        "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the workshop rimworld file in Steam"
+    },
+    "io.github.rinigus.OSMScoutServer": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.ripose_jp.Memento": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.ryubing.Ryujinx": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
     "io.github.saeugetier.photobooth": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5146,26 +3257,128 @@
     "io.github.sameboy.SameBoy": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.santiagocezar.maniatic-launcher": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
     "io.github.sgsaenger.vipster": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.sharkwouter.Minigalaxy": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.github.shiftey.Desktop": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.github.shiiion.primehack": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.shonubot.Spruce": {
+        "finish-args-flatpak-spawn-access": "Allows calling host tools for size checks and safe deletions, restricted to user-selected targets."
+    },
+    "io.github.shundhammer.qdirstat": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "io.github.sil_car.SqueezeVid": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.sithlord48.blackchocobo": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.slgobinath.SafeEyes": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.sockeye_d.godl": {
+        "finish-args-host-filesystem-access": "needed to access and modify projects outside of sandbox"
+    },
     "io.github.stella_emu.Stella": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.streetpea.Chiaki4deck": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "io.github.subhra74.Muon": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.github.swordpuffin.rewaita": {
+        "finish-args-autostart-filesystem-access": "Needed for manually creating an autostart file with specific parameters which cannot be done through Libportal"
+    },
+    "io.github.swordpuffin.wardrobe": {
+        "finish-args-dconf-talk-name": "needed to access host dconf configuration",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.sxyazi.yazi": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.tfuxu.Halftone": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "io.github.theforceengine.tfe": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "io.github.thetumultuousunicornofdarkness.cpu-x": {
+        "finish-args-flatpak-spawn-access": "access to /dev/cpu and /dev/mem is required in order to display data about CPU and memory"
+    },
+    "io.github.thiefmd.themegenerator": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "io.github.tlcfem.suanPan": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.tobagin.keysmith": {
+        "finish-args-ssh-filesystem-access": "Used for creating/saving ssh keys within the application."
+    },
+    "io.github.tobagin.secrets": {
+        "finish-args-gnupg-filesystem-access": "Used for creating gpg keys within the password manager.",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "io.github.torrent_file_editor.Torrent-file-editor": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.totoshko88.RustConn": {
+        "finish-args-ssh-filesystem-access": "RustConn is an SSH/RDP/VNC/SPICE connection manager. Read-only access to ~/.ssh is required to load user's existing SSH keys and config for SSH connections.",
+        "finish-args-has-socket-ssh-auth": "Required for SSH agent forwarding to enable key-based authentication for SSH connections without re-entering passphrases."
     },
     "io.github.trevorsandy.LPub3D": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.trigg.discover_overlay": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.github.troyeguo.koodo-reader": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
     "io.github.twanvl.MagicSetEditor2": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.ungoogled_software.ungoogled_chromium": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Access host dconf for proxy resolution",
+        "finish-args-direct-dconf-path": "Access host dconf for proxy resolution",
+        "finish-args-host-tmp-access": "Access host tmp for MPRIS media cover art",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.unrud.RecentFilter": {
+        "finish-args-arbitrary-xdg-data-rw-access": "Requires full access to xdg-data/recently-used.xbel",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.vikdevelop.SaveDesktop": {
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
+        "finish-args-legacy-icon-folder-permission": "Specifically meant to save desktop settings",
+        "finish-args-legacy-font-folder-permission": "Specifically meant to save desktop settings",
+        "finish-args-incorrect-theme-folder-permission": "Specifically meant to save desktop settings",
+        "finish-args-full-home-local-share-access": "Predates the linter rule",
+        "finish-args-full-home-config-access": "Predates the linter rule"
     },
     "io.github.voxelcubes.deepqt": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5173,8 +3386,24 @@
     "io.github.voxelcubes.panelcleaner": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.waylyrics.Waylyrics": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
     "io.github.wdaniau.fstl": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.wiiznokes.fan-control": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "io.github.wivrn.wivrn": {
+        "finish-args-unnecessary-xdg-config-openvr-create-access": "Required to set the current OpenVR runtime",
+        "finish-args-unnecessary-xdg-config-openxr-create-access": "Required to set the current OpenXR runtime",
+        "finish-args-flatpak-spawn-access": "Required to launch games on the host",
+        "finish-args-flatpak-appdata-folder-access": "Required to list games in Steam flatpak",
+        "finish-args-unnecessary-xdg-data-Steam-ro-access": "Required to list games in system Steam",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Required to list .desktop files on the host",
+        "finish-args-login1-system-talk-name": "Predates the linter rule",
+        "finish-args-own-name-io.github.wivrn.Server": "Predates the linter rule"
     },
     "io.github.woelper.Oculante": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5182,8 +3411,14 @@
     "io.github.wxmaxima_developers.wxMaxima": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.xiaoyifang.goldendict_ng": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
     "io.github.xverizex.nem_desktop": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.github.xyproto.zsnes": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "io.github.yuxshao.ptcollab": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5195,14 +3430,94 @@
     "io.github.zhrexl.thisweekinmylife": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.github.zyedidia.micro": {
+        "finish-args-flatpak-spawn-access": "users may want to use it for built-in terminal emulator",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.gitlab.Goodvibes": {
+        "appid-code-hosting-too-few-components": "the app predates this linter rule"
+    },
+    "io.gitlab.Turtlico": {
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "io.gitlab.android_translation_layer.BaseApp": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.gitlab.celleron56.libretile": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "io.gitlab.dev_nis.one-click-backup": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.gitlab.floodlight.Presenter": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.gitlab.gwendalj.package-transporter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
+    },
+    "io.gitlab.librewolf-community": {
+        "appid-code-hosting-too-few-components": "the app predates this linter rule",
+        "finish-args-own-name-wildcard-io.gitlab.librewolf": "Predates the linter rule",
+        "finish-args-own-name-wildcard-io.gitlab.firefox": "Predates the linter rule"
+    },
+    "io.gitlab.liferooter.TextPieces": {
+        "finish-args-flatpak-spawn-access": "required for running user-defined text actions in host environment"
     },
     "io.gitlab.persiangolf.voicegen": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.gitlab.zulfian1732.jollpi-text-editor": {
+        "finish-args-host-filesystem-access": "The app is a text editor intended to open and edit arbitrary files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations, similar to other text editors."
+    },
+    "io.greenfire.Greenery": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.howl.Editor": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-io.howl": "Predates the linter rule"
+    },
+    "io.itch.amcsquad.amcsquad": {
+        "module-amc-data-checker-tracks-commits": "Uses tag"
+    },
     "io.itch.azagaya.Laigter": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.itch.doctorm64.skippybot": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.itch.itch": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"
+    },
+    "io.jamulus.Jamulus": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.kapsa.drive": {
+        "finish-args-flatpak-spawn-access": "Required to spawn fusermount3 in order to run FUSE mount on a host system",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.kinvolk.Headlamp": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.kopia.KopiaUI": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.liri.Calculator": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "io.liri.Text": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "io.lmms.LMMS": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5210,11 +3525,69 @@
     "io.mango3d.LycheeSlicer": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.mgba.mGBA": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.missioncenter.MissionCenter": {
+        "finish-args-flatpak-spawn-access": "access to /proc is required in order to list running processes and their respective resource usage; see https://github.com/flathub/flathub/pull/4313#discussion_r1257263670",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "read-only access to xdg-data/flatpak{,/exports/share} is required to query installed apps on the system and present the ones that are running to the user; see https://github.com/flathub/flathub/pull/4313#discussion_r1257263670",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-systemd1-system-talk-name": "Predates the linter rule"
+    },
+    "io.mpv.Mpv": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "module-x264-checker-tracks-commits": "Tracks stable branch commits, doesn't have releases",
+        "module-luajit-checker-tracks-commits": "Tracks stable branch commits, doesn't have releases",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "io.neovim.nvim": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "io.osdn.simplesok": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.ossia.score": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.otsaloma.gaupol": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.otsaloma.nfoview": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "io.photoflare.photoflare": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.podman_desktop.PodmanDesktop": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "io.posidon.Paper": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.qt.Linguist": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.qt.QtCreator": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.qt.qdbusviewer": {
+        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access"
+    },
+    "io.qt.qtdesignstudio": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
     "io.seamly.seamly2d": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5225,23 +3598,109 @@
     "io.sourceforge.chart_geany.chart-geany": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "io.sourceforge.xtrkcad_fork.xtrkcad": {
+        "finish-args-home-filesystem-access": "Needed since the app reads/writes track plans stored anywhere on users home directory"
+    },
+    "io.stoplight.studio": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "io.typora.Typora": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "io.wavebox.Wavebox": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "io.webtorrent.WebTorrent": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "it.cuteworks.pacmanlogviewer": {
+        "finish-args-host-var-access": "Predates the linter rule"
+    },
     "it.fabiodistasio.AntaresSQL": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "it.mijorus.collector": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "it.mijorus.gearlever": {
+        "finish-args-flatpak-spawn-access": "Required to launch AppImages that the user integrates into the system menu",
+        "finish-args-host-tmp-access": "Required to extract some large AppImages into the /tmp directory: the tmpfs under /run/user/1000 might be too small",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "it.mijorus.smile": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "it.mijorus.whisper": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "it.mq1.TinyWiiBackupManager": {
+        "finish-args-host-filesystem-access": "Used for loading the rom dumps from anywhere in the home directory or from a drive, and for transferring them to the Wii drive."
     },
     "it.unibo.tuprolog.ide": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "jp.yvt.OpenSpades": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "la.ogri.strongbox": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "life.bolls.bolls": {
+        "finish-args-full-home-config-access": "Predates the linter rule"
+    },
+    "lol.janjic.Splitcat": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "md.obsidian.Obsidian": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "me.ahola.aphototoollibre": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "me.amankhanna.opendeck": {
+        "finish-args-flatpak-spawn-access": "host shell access required for running user-provided commands and also to start plugins using Wine and Node"
     },
     "me.broken_by.PdfMetadataEditor": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "me.dusansimic.DynamicWallpaper": {
+        "finish-args-unnecessary-xdg-data-backgrounds-create-access": "https://github.com/dusansimic/dynamic-wallpaper/issues/5",
+        "finish-args-unnecessary-xdg-data-gnome-background-properties-create-access": "https://github.com/dusansimic/dynamic-wallpaper/issues/5"
+    },
+    "me.iepure.devtoolbox": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "me.kozec.syncthingtk": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "me.mitya57.ReText": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "me.sanchezrodriguez.passes": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "me.simakis.dropboxignore": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "me.timschneeberger.GalaxyBudsClient": {
+        "finish-args-own-name-wildcard-org.kde": "The used version of the toolkit Avalonia only supports legacy KDE system tray icons: https://github.com/AvaloniaUI/Avalonia/issues/13782"
+    },
+    "media.emby.EmbyServer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "menu.kando.Kando": {
+        "finish-args-flatpak-spawn-access": "Required because Kando is an app-launcher",
+        "finish-args-kwin-talk-name": "Required to talk to a KWin script for getting the focused window name"
+    },
+    "moe.clover.mm3d": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "moe.tundra.Tundra": {
+        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule"
     },
     "net.agalwood.Motrix": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5249,17 +3708,48 @@
     "net.biniou.LeBiniou": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.blumia.pineapple-pictures": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.blumia.pineapple-steam-recording-exporter": {
+        "finish-args-flatpak-appdata-folder-access": "To access and export video recordings under the Steam client packaged as Flatpak applications"
+    },
     "net.cebix.basilisk": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.christianbeier.Gromit-MPX": {
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule"
+    },
     "net.christianbeier.MultiVNC": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.codelogistics.webapps": {
+        "finish-args-arbitrary-xdg-data-rw-access": "The app creates and removes desktop files in ~/.local/share/applications."
+    },
+    "net.cozic.joplin_desktop": {
+        "external-gitmodule-url-found": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "net.daase.journable": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.danigm.loop": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "net.darkradiant.DarkRadiant": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.davidotek.pupgui2": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
     "net.dengine.Doomsday": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.displaycal.DisplayCAL": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "net.fasterland.converseen": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5267,11 +3757,26 @@
     "net.fsuae.FS-UAE": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.giuspen.cherrytree": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "net.gpro.gproapp": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.hovancik.Stretchly": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "net.imaginaryinfinity.Squiid": {
+        "finish-args-not-defined": "Is a command line application"
+    },
+    "net.jami.Jami": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
     "net.jammr.jammr": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.jenyay.Outwiker": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "net.kuribo64.melonDS": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5282,16 +3787,121 @@
     "net.longturn.freeciv21": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.lugsole.bible_gui": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "net.lutris.Lutris": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-umu-create-access": "Uses shared installation for the umu runtime",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "net.mancubus.SLADE": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.AVIMetaEdit": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.BWFMetaEdit": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.DVAnalyzer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.MOVMetaEdit": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.MediaConch": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.MediaInfo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "net.mediaarea.QCTools": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.meshlab.MeshLab": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.mullvad.MullvadBrowser": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.mozilla.mullvadbrowser": "Predates the linter rule"
+    },
+    "net.natesales.Aviator": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.nokyan.Resources": {
+        "finish-args-flatpak-spawn-access": "Required to spawn a small executable dedicated to finding running processes in /proc",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to detect user-wide installed Flatpak applications by searching for .desktop files",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "net.nymtech.NymVPN": {
+        "finish-args-host-var-access": "needed to access the daemon logs"
     },
     "net.odamex.Odamex": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.oz9aec.Gpredict": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "net.pioneerspacesim.Pioneer": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
     "net.poedit.Poedit": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.purrdata.PurrData": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.redeclipse.RedEclipse": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "net.retrodeck.retrodeck": {
+        "finish-args-unnecessary-xdg-data-Steam-rw-access": "SteamOS is the primary target of the application and it does not ship an xsettings daemon or xdg-desktop-portal-gtk: https://github.com/ValveSoftware/SteamOS/issues/803",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "SteamOS is the primary target of the application and it does not ship an xsettings daemon or xdg-desktop-portal-gtk: https://github.com/ValveSoftware/SteamOS/issues/803",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-talk-name": "Predates the linter rule"
+    },
+    "net.rpcs3.RPCS3": {
+        "module-rpcs3-source-git-branch": "Needed for custom updater to update once a day per upstream recommendation.",
+        "flathub-json-automerge-enabled": "Grandfather in on condition of weekly update workflow. Without automerge builds fail as branch moves to another SHA",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "net.rpdev.OpenTodoList": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.runelite.RuneLite": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "net.scribus.Scribus": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "net.sf.VICE": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.sf.nootka": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "net.shadps4.shadPS4": {
@@ -5303,24 +3913,62 @@
     "net.sonic_pi.SonicPi": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.sonobus.SonoBus": {
+        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.SonoBus": "Predates the linter rule"
+    },
+    "net.sourceforge.Chessx": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "net.sourceforge.Fillets": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "net.sourceforge.GrandOrgue": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "net.sourceforge.Hugin": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.sourceforge.Lifeograph": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.sourceforge.Teo": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "net.sourceforge.VMPK": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.sourceforge.artha.Artha": {
+        "finish-args-own-name-org.artha.unique": "Predates the linter rule"
+    },
+    "net.sourceforge.dmidiplayer": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "net.sourceforge.efaxgtk": {
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-own-name-org.cgu.progs.efax_gtk": "Predates the linter rule"
     },
+    "net.sourceforge.electrip.Electrip": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "net.sourceforge.fspclient": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "net.sourceforge.fuse_emulator.Fuse": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.sourceforge.kmetronome": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.sourceforge.kmidimon": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "net.sourceforge.paulstretch": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "net.sourceforge.projectM": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "net.sourceforge.qtpfsgui.LuminanceHDR": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5331,17 +3979,76 @@
     "net.sourceforge.wavbreaker": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "net.unvanquished.Unvanquished": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "net.veloren.veloren": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "net.waterfox.waterfox": {
+        "finish-args-own-name-wildcard-org.mozilla.waterfox": "Predates the linter rule"
+    },
+    "net.werwolv.ImHex": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "net.wz2100.wz2100": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "net.xmind.XMind": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "network.loki.Session": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "nl.openoffice.bluefish": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "nl.sarine.gpx-viewer": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "one.ablaze.floorp": {
+        "finish-args-own-name-wildcard-org.mozilla.floorp": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Needed for manually creating application .desktop files for Floorp's Web Apps feature",
+        "finish-args-unnecessary-xdg-data-icons-create-access": "Needed as Floorp's Web Apps feature downloads and installs icons for each website that the user adds",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "Needed for Breeze, etc. to use their colour scheme - upstream Firefox permission"
+    },
+    "one.k8ie.Identities": {
+        "finish-args-has-socket-gpg-agent": "Needs to be able to use your host's GPG agent to decrypt password store entries",
+        "finish-args-gnupg-filesystem-access": "Due to how GPG handles working with a remote agent, the Flatpak's GPG needs to know which public keys are available on the \"remote\" host - see https://wiki.gnupg.org/AgentForwarding"
+    },
     "one.mixin.messenger": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.DolphinEmu.dolphin-emu": {
+        "module-dolphin-emu-checker-tracks-commits": "Uses beta channel",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.KekikAkademi.BTKSorgu": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org._2009scape.Launcher": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "org.adishatz.syncpasswd": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "org.aegisub.Aegisub": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.aliflang.lang": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.altlinux.Tuner": {
+        "finish-args-unnecessary-xdg-config-dconf-rw-access": "needed to access host dconf configuration at launch time",
+        "finish-args-direct-dconf-path": "needed to access host dconf configuration",
+        "finish-args-dconf-talk-name": "needed to access host dconf configuration"
+    },
+    "org.apache.netbeans": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.archivekeep.ArchiveKeep": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5354,6 +4061,99 @@
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.asamk.SignalCli": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.audacityteam.Audacity": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.avidemux.Avidemux": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.azahar_emu.Azahar": {
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Azahar has a feature which creates .desktop files in ~/.local/share/applications",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.beeref.BeeRef": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.bino3d.bino": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.bionus.Grabber": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.bleachbit.BleachBit": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.gnome.Bleachbit": "Predates the linter rule"
+    },
+    "org.blender.Blender": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.bluej.BlueJ": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.bluesabre.MenuLibre": {
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "MenuLibre manages desktop file entries. It needs to create desktop files in xdg-data/applications",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "MenuLibre manages desktop file entries. It needs to create desktop files in xdg-data/applications",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.buhocms.BuhoCMS": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.bunkus.mkvtoolnix-gui": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.caione.GScope": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.catacombing.kumo": {
+        "finish-args-only-wayland": "this program doesn't have x11 support"
+    },
+    "org.chrisoft.qmidiplayer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.chromium.Chromium": {
+        "finish-args-contains-both-x11-and-wayland": "optional wayland support",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.claws_mail.Claws-Mail": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.clementine_player.Clementine": {
+        "finish-args-own-name-org.kde.StatusNotifierItem-2-2": "Predates the linter rule"
+    },
+    "org.cloudcompare.CloudCompare": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.cockpit_project.CockpitClient": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
+    "org.codeberg.dimkard.glossaico": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
+    "org.codeblocks.codeblocks": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.contourterminal.Contour": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
+    "org.coolero.Coolero": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
+    "org.cryptomator.Cryptomator": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.cubocore.CoreAction": {
@@ -5401,69 +4201,600 @@
     "org.cubocore.CoreTime": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.cvfosammmm.Setzer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.d3cod3.Mosaic": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.darktable.Darktable": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.darktable.service": "Predates the linter rule"
+    },
+    "org.davmail.DavMail": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.denemo.Denemo": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.develz.Crawl": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.dpsoftware.FireflyLuciferin": {
+        "finish-args-kwin-talk-name": "Predates the linter rule"
+    },
     "org.dune3d.dune3d": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.dupot.easyflatpak": {
+        "finish-args-flatpak-spawn-access": "Required to install then override some flatpak application (for example asking game folder for steam or lutris)"
+    },
+    "org.dust3d.dust3d": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.easycoding.TunedSwitcher": {
+        "finish-args-systemd1-system-talk-name": "Predates the linter rule"
+    },
+    "org.easyrpg.player": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.eclipse.Java": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.eclipse.iot.fourdiac.Ide": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.eclipse.sumo": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.emptyflow.ArdorQuery": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.enjoyingfoss.FOSStriangulator": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.equeim.Tremotesf": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.eu.encom.spectral": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "org.exbin.BinEd": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.expresslrs.ExpressLRSConfigurator": {
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
     "org.famistudio.FamiStudio": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.fcitx.Fcitx5": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-unnecessary-xdg-config-fcitx-create-access": "need for simulating ibus daemon and changing kde system xkb settings",
+        "finish-args-unnecessary-xdg-config-kxkbrc-rw-access": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-cache-ibus-create-access": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-config-ibus-create-access": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Input method daemon need to talk with both XWayland/X11/Wayland applications at the same time"
+    },
+    "org.fdroid.Repomaker": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.fedoraproject.MediaWriter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.feichtmeier.Musicpod": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.ferdium.Ferdium": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.filezillaproject.Filezilla": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "org.filmulator.Filmulator": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.firestormviewer.FirestormViewer": {
+        "finish-args-own-name-com.secondlife.ViewerAppAPIService": "Predates the linter rule"
+    },
+    "org.flameshot.Flameshot": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.flathub.exceptions": {
+        "appid-filename-mismatch": "required as I like pies",
+        "toplevel-no-command": "another nonsensical reason",
+        "flathub-json-deprecated-i386-arch-included": "this would be a warning but is also skipped"
+    },
+    "org.flathub.exceptions_wildcard": {
+        "*": "ignore all errors and warnings"
+    },
+    "org.flathub.flatpak-external-data-checker": {
+        "*": "used by flathub infra",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.flatpak.Builder": {
+        "*": "used by flathub infra",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.flatpak.Builder.BaseApp": {
+        "*": "used by flathub infra"
+    },
+    "org.flatpak.qtdemo": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.flozz.yoga-image-optimizer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.flycast.Flycast": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.fontforge.FontForge": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freac.freac": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freecad.FreeCAD": {
+        "finish-args-flatpak-spawn-access": "Needed to launch OpenSCAD flatpak as a command-line tool for the importer.",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freedesktop.Bustle": {
+        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access"
+    },
+    "org.freedesktop.GstDebugViewer": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.freedesktop.LinuxAudio.BaseExtension": {
+        "finish-args-not-defined": "This provides an extension point only",
+        "toplevel-no-command": "This provides an extension point only",
+        "appstream-metainfo-missing": "This provides an extension point only"
+    },
+    "org.freedesktop.Piper": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.freedesktop.Platform.ClInfo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.freedesktop.Platform.GlxInfo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.freedesktop.Platform.VaInfo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.freedesktop.Platform.VdpauInfo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.freedesktop.Platform.VulkanInfo": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.freedesktop.Sdk.Extension.dmd": {
+        "module-dmd-checker-tracks-commits": "Uses tag, grandfathered"
+    },
+    "org.freedesktop.Sdk.Extension.golang": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "org.freedesktop.Sdk.Extension.rust-stable": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "org.freedesktop.Tuhi": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.tuhi1": "Predates the linter rule"
+    },
+    "org.freedesktop.adriconf": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freedesktop.appstream-glib": {
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freedesktop.appstream.cli": {
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freedesktop.appstream.generator": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.freedesktop.dabrain34.GstPipelineStudio": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.freedesktop.fwupd": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.freefilesync.FreeFileSync": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.freeplane.App": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.frescobaldi.Frescobaldi": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.fritzing.Fritzing": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.gabmus.gfeeds": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
+    "org.gabmus.hydrapaper": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
     "org.gabmus.notorious": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.gabmus.unifydmin": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-ssh-filesystem-access": "Predates the linter rule"
+    },
+    "org.gahshomar.Gahshomar": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gajim.Gajim": {
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
     "org.gaphor.Gaphor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.garudalinux.firedragon": {
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.mozilla.firedragon": "Predates the linter rule",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "Needed for Breeze, etc. to use their colour scheme - upstream Firefox permission"
+    },
+    "org.geany.Geany": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.geeqie.Geeqie": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.geogebra.GeoGebra": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.gephi.Gephi": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.getzola.zola": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.ghidra_sre.Ghidra": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.gimp.GIMP": {
+        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "gtk-3.0 and GIMP config.",
+        "finish-args-unnecessary-xdg-config-GIMP-create-access": "GIMP config always used",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gitfourchette.gitfourchette": {
+        "finish-args-flatpak-spawn-access": "Start external merge tool via flatpak-spawn",
+        "finish-args-has-socket-ssh-auth": "Authenticate with git remotes via host's ssh-agent",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gmusicbrowser.gmusicbrowser": {
+        "finish-args-own-name-org.gmusicbrowser": "Predates the linter rule"
+    },
+    "org.gnode.NixView": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Boxes": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Boxes.Extension.OsinfoDb": {
+        "module-osinfo-db-checker-tracks-commits": "Uses tag, grandfathered"
+    },
     "org.gnome.Brasero": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Builder": {
+        "finish-args-arbitrary-dbus-access": "IDEs tend to require direct dbus access",
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-user-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.gnome.Calendar": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.Characters": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.ColorViewer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Connections": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Contacts": {
+        "finish-args-unnecessary-xdg-data-pixmaps-create-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-cache-evolution-ro-access": "the app predates this linter rule, used for evolution data server",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.DejaDup": {
+        "finish-args-flatpak-appdata-folder-access": "Users would expect that a full home backup would include flatpak application configuration and data",
+        "finish-args-flatpak-spawn-access": "Required to spawn fusermount, mounting the user's backup via FUSE",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.gnome.Devhelp": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Evince": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.gnome.evince": "Predates the linter rule",
+        "finish-args-own-name-org.gnome.evince.Daemon": "Predates the linter rule"
+    },
+    "org.gnome.Evolution": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
     },
     "org.gnome.FileRoller": {
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-own-name-org.gnome.ArchiveManager1": "Predates the linter rule"
     },
+    "org.gnome.Firmware": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.GHex": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.GTG": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.Geary": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.Genius": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-own-name-org.gnome.genius": "Predates the linter rule"
+    },
+    "org.gnome.Glade": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.gnome.Gtranslator": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.HexGL": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Keysign": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Logs": {
+        "finish-args-host-var-access": "Predates the linter rule"
+    },
+    "org.gnome.Lollypop": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
+    "org.gnome.Loupe": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Music": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.NautilusPreviewer": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.NetworkDisplays": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Notes": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.OCRFeeder": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-freedesktop-dbus-system-talk-name": "Predates the linter rule",
+        "finish-args-freedesktop-dbus-talk-name": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.OfficeRunner": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.Papers": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
     "org.gnome.Pinpoint": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.gnome.Polari": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-own-name-org.freedesktop.Telepathy.Client.Polari": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Telepathy.Client.Polari": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Telepathy.Client.TpGLibRequestAndHandle": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.Telepathy.AccountManager": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.Telepathy.ChannelDispatcher": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.Telepathy.MissionControl5": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.Telepathy.ConnectionManager.idle": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Telepathy.Connection.idle.irc": "Predates the linter rule"
+    },
+    "org.gnome.PowerStats": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Recipes": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Rhythmbox3": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Shotwell": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.SoundJuicer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.SoundRecorder": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.SwellFoop": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Tau": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.gnome.TextEditor": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.Todo": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.Tomboy": {
+        "finish-args-freedesktop-dbus-system-talk-name": "Predates the linter rule"
+    },
+    "org.gnome.Totem": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.Totem.Devel": {
+        "module-totem-source-git-no-tag-commit-branch": "This is the development version of Totem, tracking upstream",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "manifest-file-is-symlink": "Predates the linter rule"
+    },
+    "org.gnome.World.PikaBackup": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to mount xdg-data/flatpak:ro to undo the tmpfs mount Flatpak does on --filesystem=host. The directory contains the Flatpak privileges overrides and app data that some people want to include in their backups.",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.gnome.baobab": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.gnome.design.SymbolicPreview": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.dspy": {
+        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access"
+    },
+    "org.gnome.eog": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.font-viewer": {
+        "finish-args-unnecessary-xdg-data-fonts-create-access": "required to save fonts"
+    },
+    "org.gnome.gThumb": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.gedit": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.gitg": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.gnome.gitlab.Cowsay": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.gitlab.bazylevnik0.Convolution": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "org.gnome.gitlab.ilhooq.Bookup": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.gnome.gitlab.johannesjh.favagtk": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.gitlab.somas.Apostrophe": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.gnome.glabels-3": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.meld": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnome.moserial": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.gnome.seahorse.Application": {
+        "finish-args-ssh-filesystem-access": "Predates the linter rule",
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnu.emacs": {
+        "finish-args-flatpak-spawn-access": "required to access external tools since the Emacs ecosystem expects to lean heavily on them",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.gnu.pspp": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.gnucash.GnuCash": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.gnumeric.Gnumeric": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gnupg.GPA": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
+    },
+    "org.godotengine.Godot": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Godot will fail to start up in Wayland sessions as X11 is still the default. The change this error arises from, https://github.com/flathub/org.godotengine.Godot/pull/170, predates this linter rule.",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.godotengine.Godot3": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.godotengine.Godot3Sharp": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.godotengine.GodotSharp": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it",
+        "finish-args-contains-both-x11-and-wayland": "Required as with fallback-x11 socket, Godot will fail to start up in Wayland sessions as X11 is still the default.",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.goldendict.GoldenDict": {
+        "module-goldendict-source-git-branch": "Needed for x-checker as upstream does not tag releaases."
     },
     "org.gottcode.FocusWriter": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5472,11 +4803,30 @@
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-own-name-org.gpodder": "Predates the linter rule"
     },
+    "org.gpodder.gpodder-adaptive": {
+        "finish-args-own-name-wildcard-org.gpodder": "Predates the linter rule"
+    },
     "org.gramps_project.Gramps": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.greenfoot.Greenfoot": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.grisbi.Grisbi": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.gtimelog.GTimeLog": {
+        "finish-args-own-name-org.gtimelog": "Predates the linter rule"
+    },
+    "org.gtkhash.gtkhash": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.guitarix.Guitarix": {
+        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Guitarix": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.hedgewars.Hedgewars": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "org.horizon_eda.HorizonEDA": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5484,27 +4834,570 @@
     "org.hydrogenmusic.Hydrogen": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.indii.mendingwall": {
+        "finish-args-unnecessary-xdg-config-autostart-create-access": "install autostart programs to restore themes on desktop login, with additional features required beyond those provided by the background portal",
+        "finish-args-unnecessary-xdg-config-plasma-workspace-create-access": "install autostart programs to restore themes on desktop login, which run earlier in the startup process for KDE",
+        "finish-args-direct-dconf-path": "save and restore desktop environment theme configuration stored in GSettings dconf backend",
+        "finish-args-unnecessary-xdg-config-dconf-rw-access": "save and restore desktop environment theme configuration stored in GSettings dconf backend",
+        "finish-args-dconf-talk-name": "save and restore desktop environment theme configuration stored in GSettings dconf backend",
+        "finish-args-arbitrary-xdg-config-rw-access": "save and restore desktop environment theme configuration stored in configuration files",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-create-access": "save and restore desktop environment theme configuration stored in configuration files",
+        "finish-args-unnecessary-xdg-config-gtk-4.0-create-access": "save and restore desktop environment theme configuration stored in configuration files",
+        "finish-args-unnecessary-xdg-config-xsettingsd-create-access": "save and restore desktop environment theme configuration stored in configuration files",
+        "finish-args-host-var-access": "read .desktop files of applications installed on the system",
+        "finish-args-flatpak-system-folder-access": "read .desktop files of Flatpak applications installed on the system",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "read .desktop files of Flatpak applications installed by the user",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "batch save updated .desktop files to organise applications between the menus of different desktop environments"
+    },
+    "org.inkscape.Inkscape": {
+        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "Access xdg-config/gtk-3.0 for bookmarks",
+        "finish-args-contains-both-x11-and-wayland": "it can launch non-wayland UI via plugins",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.jabref.jabref": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "org.jamovi.jamovi": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.jaspstats.JASP": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.jflap.JFLAP": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.jitsi.jitsi-meet": {
+        "finish-args-login1-talk-name": "Predates the linter rule"
+    },
+    "org.jreleaser.cli": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.jupyter.JupyterLab": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.karapulse.Karapulse": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.SymbolEditor": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.akregator": {
+        "finish-args-own-name-org.freedesktop.Akonadi": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Akonadi": "Predates the linter rule",
+        "finish-args-own-name-org.kde.accountwizard": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kaddressbook": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.kde.pim": "Predates the linter rule",
+        "finish-args-own-name-org.kde.pimsettingsexporter": "Predates the linter rule"
+    },
+    "org.kde.amarok": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.angelfish": {
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.arianna": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.ark": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.artikulate": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.atlantik": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.blinken": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.bomber": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.bovo": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.cantor": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.digikam": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.discover": {
+        "finish-args-flatpak-system-folder-access": "Needs access to system-wide flatpak installation so that it can manage them",
+        "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needs access to user-wide flatpak installation so that it can manage them",
+        "finish-args-flatpak-system-talk-name": "Talks to the system-wide flatpak dbus address in order to query existence of flatpaks and send installation commands to it",
+        "finish-args-flatpak-appdata-folder-access": "Needs access to settings and user data of other apps ",
+        "finish-args-flatpak-spawn-access": "Runs host binaries in order to successfully install apps"
+    },
+    "org.kde.dolphin": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.elisa": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.falkon": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.filelight": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.gcompris": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.ghostwriter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.granatier": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.gwenview": {
+        "finish-args-unnecessary-xdg-data-Trash-rw-access": "required for access to Trash until Portal support is added",
+        "finish-args-unnecessary-xdg-cache-thumbnails-rw-access": "required for thumbnail reading and generation",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.hana": {
+        "finish-args-home-filesystem-access": "Needs to save images in an user defined folder"
     },
     "org.kde.haruna": {
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
+    "org.kde.index": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.isoimagewriter": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.juk": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kaffeine": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kalzium": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kamoso": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kanagram": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kapman": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kate": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.katomic": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kbibtex": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kblackbox": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kblocks": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kbounce": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kbreakout": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kbruch": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kcachegrind": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kcalc": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kclock": {
+        "finish-args-own-name-org.kde.kclockd": "Predates the linter rule"
+    },
+    "org.kde.kcolorchooser": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kdenlive": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kdevelop": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.kdevelop": "Predates the linter rule"
+    },
+    "org.kde.kdiamond": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kdiff3": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kfind": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kfourinline": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kgeography": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kgoldrunner": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kgraphviewer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.khangman": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kid3": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kig": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kigo": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kile": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.killbots": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kimagemapeditor": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kiriki": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kiten": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kjournaldbrowser": {
+        "finish-args-host-var-access": "required for read access to system journal log database"
+    },
+    "org.kde.kjumpingcube": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kleopatra": {
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kwatchgnupg": "Predates the linter rule"
+    },
+    "org.kde.klettres": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.klickety": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.klines": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kmahjongg": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kmines": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kmplot": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kmymoney": {
+        "finish-args-home-filesystem-access": "required for writing and deleting backup and temporary files",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.knavalbattle": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.knetwalk": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.knights": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.koko": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kolf": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kollision": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kolourpaint": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kommit": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-gpg-agent": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.kde.kompare": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kongress": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-own-name-org.kde.kongressac": "Predates the linter rule"
+    },
+    "org.kde.konquest": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.konsole": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kontact": {
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.Akonadi": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Akonadi": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Akonadi.Agent": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Akonadi.Control": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.freedesktop.Akonadi.Resource": "Predates the linter rule",
+        "finish-args-own-name-org.kde.accountwizard": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.kde.akonadiconsole": "Predates the linter rule",
+        "finish-args-own-name-org.kde.akregator": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kaddressbook": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kalarm": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kalendarac": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.kde.kioexec": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kmail": "Predates the linter rule",
+        "finish-args-own-name-org.kde.kmail2": "Predates the linter rule",
+        "finish-args-own-name-org.kde.korgac": "Predates the linter rule",
+        "finish-args-own-name-org.kde.korganizer": "Predates the linter rule",
+        "finish-args-own-name-org.kde.merkuro": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.kde.pim": "Predates the linter rule",
+        "finish-args-own-name-org.kde.pimsettingexporter": "Predates the linter rule",
+        "finish-args-own-name-org.kde.sieveeditor": "Predates the linter rule"
+    },
+    "org.kde.konversation": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kpat": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.krdc": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.krename": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kreversi": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.krita": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kronometer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kruler": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.krusader": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kshisen": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.ksirk": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.ksnakeduel": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.ksquares": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kstars": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.ksudoku": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kteatime": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.ktechlab": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.ktimetracker": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.ktorrent": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.ktouch": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.kde.ktuberling": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kturtle": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kubrick": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.kwordquiz": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.kwrite": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.kxstitch": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
     "org.kde.labplot": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.labplot2": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.lokalize": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.lskat": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.marble": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.kde.minuet": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.okteta": {
+        "appstream-missing-developer-name": "grandfathered due to unannounced linter changes",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.okular": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-talk-name": "Predates the linter rule"
     },
     "org.kde.optiimage": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.kde.palapeli": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.parley": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.peruse": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.picmi": {
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
+    },
+    "org.kde.pix": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.qmlkonsole": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
+    },
+    "org.kde.rocs": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.skanlite": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.skanpage": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.skrooge": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.spectacle": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-kwin-talk-name": "Predates the linter rule",
+        "finish-args-plasmashell-talk-name": "Predates the linter rule"
+    },
+    "org.kde.subtitlecomposer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.kde.sweeper": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.tellico": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.trojita": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kde.umbrello": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-own-name-org.kde.umbrello-2": "Predates the linter rule"
+    },
+    "org.kde.vvave": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kde.yakuake": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-kwin-talk-name": "Predates the linter rule",
+        "finish-args-plasmashell-talk-name": "Predates the linter rule"
+    },
+    "org.keepassxc.KeePassXC": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule",
+        "finish-args-own-name-org.freedesktop.secrets": "Predates the linter rule"
+    },
+    "org.kekikakademi.eFatura": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kekikakademi.ntvHaber": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.kicad.KiCad": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.kiwix.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.ksnip.ksnip": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.lamport.tla.toolbox": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5521,14 +5414,56 @@
     "org.librehunt.Organizer": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.libreoffice.LibreOffice": {
+        "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/111> 'GTK bookmarks do not appear in the flatpak version of LibreOffice'",
+        "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/136> 'fontconfig user configuration'",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-org.libreoffice.LibreOfficeIpc0": "Predates the linter rule"
+    },
+    "org.librepcb.LibrePCB": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.libretro.RetroArch": {
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-talk-name": "Predates the linter rule"
+    },
+    "org.libsdl.Maelstrom": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.libvips.nip4": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.libvips.vipsdisp": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.linux_hardware.hw-probe": {
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.linuxshowplayer.LinuxShowPlayer": {
+        "finish-args-flatpak-spawn-access": "Required by CommandCue(s) to allow users to interact with external tools",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.love2d.love2d": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
     "org.lvnauth.LVNAuth": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.lyx.LyX": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.mamedev.MAME": {
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.mapeditor.Tiled": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.mattbas.Glaxnimate": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.mavlink.qgroundcontrol": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5548,14 +5483,44 @@
     "org.mmass.mMass": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.mobsya.ThymioSuite": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "org.moneymanagerex.MMEX": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.mosh.mosh": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "org.mozilla.Thunderbird": {
+        "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system",
+        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.mozilla.thunderbird": "Predates the linter rule",
+        "finish-args-own-name-wildcard-org.mozilla.thunderbird_beta": "Predates the linter rule"
+    },
+    "org.mozilla.firefox": {
+        "finish-args-own-name-wildcard-org.mozilla.firefox_beta": "Predates the linter rule"
     },
     "org.musescore.MuseScore": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.musicbrainz.Picard": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "org.mypaint.MyPaint": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.naev.Naev": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "org.neverball.Neverball": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.nickvision.cavalier": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "org.nickvision.money": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5572,10 +5537,43 @@
     "org.nomacs.ImageLounge": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.nongnu.gsequencer.gsequencer": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.nuspell.Nuspell": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.octave.Octave": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.olivevideoeditor.Olive": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.onlyoffice.desktopeditors": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.openclonk.OpenClonk": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "org.opencpn.OpenCPN": {
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-systemd1-system-talk-name": "Predates the linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.openkj.OpenKJ": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.openmsx.openMSX": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.openmw.OpenMW": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.openscad.OpenSCAD": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5583,23 +5581,127 @@
     "org.openscopeproject.TrguiNG": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.openshot.OpenShot": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.openttd.OpenTTD": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.otfried.Ipe": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
     "org.paraview.ParaView": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.pdfstitcher.pdfstitcher": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.pegasus_frontend.Pegasus": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.pencil2d.Pencil2D": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.photoqt.PhotoQt": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.pitivi.Pitivi": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.pjbroad.EternallandsClient": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
     "org.plomgrading.PlomClient": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.polymc.PolyMC": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.ppsspp.PPSSPP": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.previewqt.PreviewQt": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.prismlauncher.PrismLauncher": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.processing.processingide": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.purei.Play": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.pvermeer.WebAppHub": {
+        "finish-args-flatpak-system-folder-access": "Used to fetch the icons of system installed flatpak browsers.",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Used to fetch the icons of user installed flatpak browsers.",
+        "finish-args-flatpak-spawn-access": "This is needed to fetch installed browser information and to run the created Web App from this application.",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "Used to create and delete owned desktop files for web apps.",
+        "finish-args-flatpak-appdata-folder-access": "Used to create isolated profile folder for flatpak browsers. For some flatpak browsers it's necessary to create a directory in their sandbox for profile isolation. For some browsers it's used to update the isolated profile config for a minimal ui."
+    },
+    "org.pyzo.pyzo": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.qbittorrent.qBittorrent": {
+        "module-libtorrent-checker-tracks-commits": "Tracks stable, low maintenace branch commits",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.qelectrotech.QElectroTech": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.qgis.qgis": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.qownnotes.QOwnNotes": {
+        "flathub-json-automerge-enabled": "Verified application",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.quassel_irc.QuasselClient": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "org.quelea.Quelea": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.quetoo.Quetoo": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
     "org.qxmledit.QXmlEdit": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.raceintospace.Raceintospace": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.racket_lang.Racket": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.radare.iaito": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
     "org.recoll.recoll": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.remmina.Remmina": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-flatpak-spawn-access": "Needed to launch programs on the host specified by the user",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
     "org.rncbc.qsynth": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5607,14 +5709,77 @@
     "org.rncbc.qtractor": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.robocode.Robocode": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
     "org.rolisteam.rolisteam": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.roojs.roobuilder": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.sabnzbd.sabnzbd": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.scantailor.ScanTailor": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.scilab.Scilab": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.scintilla.SciTE": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.scummvm.ScummVM": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.shadered.SHADERed": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.shotcut.Shotcut": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.signal.Signal": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
+    },
+    "org.sil.Bloom": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.sil.FieldWorks": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.sil.dictionary-app-builder": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.sil.keyboard-app-builder": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.sil.reading-app-builder": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.sil.scripture-app-builder": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.siril.Siril": {
+        "finish-args-flatpak-spawn-access": "required to interact with third-party applications like astrometry.net for plate solving and other astronomical image processing workflows",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.skytemple.SkyTemple": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.solarus_games.solarus.Launcher": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.sonic3air.Sonic3AIR": {
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+    },
+    "org.speedcrunch.SpeedCrunch": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
     "org.spyder_ide.spyder": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5622,13 +5787,63 @@
     "org.sqlitebrowser.sqlitebrowser": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.squey.Squey": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.stellarium.Stellarium": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.stochas.Stochas": {
+        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Stochas": "Predates the linter rule"
     },
     "org.sugarlabs.MusicBlocks": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.surge_synth_team.surge-xt": {
+        "appid-unprefixed-bundled-extension-org.freedesktop.LinuxAudio.Plugins.Surge-XT": "Predates the linter rule"
+    },
+    "org.swi_prolog.swipl": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.synfig.SynfigStudio": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.syntalos.syntalos": {
+        "finish-args-arbitrary-dbus-access": "the app requires direct dbus access",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.tabos.maxcontrol": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.tabos.roger": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.tabos.saldo": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.telegram.desktop": {
+        "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "external-gitmodule-url-found": "Predates the linter rule",
+        "module-tg_owt-checker-tracks-commits": "Manually updated, grandfathered",
+        "module-tde2e-checker-tracks-commits": "Manually updated"
+    },
     "org.telesculptor.TeleSculptor": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.tenacityaudio.Tenacity": {
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.texstudio.TeXstudio": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.thonny.Thonny": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.tibirna.qgit": {
@@ -5640,17 +5855,81 @@
     "org.tomviz.Tomviz": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.trelby.Trelby": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.tropy.Tropy": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.tug.texworks": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
     "org.turbowarp.TurboWarp": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.tuxemon.Tuxemon": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.tuxpaint.Tuxpaint": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.ultimatepp.TheIDE": {
+        "finish-args-flatpak-spawn-access": "required to execute various host binaries, including compiler, debugger, and git within the application",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.upbge.UPBGE": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
     "org.upscayl.Upscayl": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.vassalengine.vassal": {
+        "finish-args-home-filesystem-access": "Needed to browse external game module files and saved games folders"
+    },
     "org.verapdf.veraPDF": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "org.vertcoin.vertcoin-qt": {
+        "finish-args-host-var-access": "Predates the linter rule"
+    },
+    "org.videolan.VLC": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.viking.Viking": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.vim.Vim": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-tmp-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.vinegarhq.Vinegar": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "org.virt_manager.virt-manager": {
+        "finish-args-ssh-filesystem-access": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+        "finish-args-own-name-org.virt-manager.virt-manager": "Predates the linter rule"
+    },
+    "org.virt_manager.virt-viewer": {
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
     "org.virtualxt.VirtualXT": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "org.wezfurlong.wezterm": {
+        "finish-args-flatpak-spawn-access": "required to spawn the user's shell and other commands on the host system; it's the primary purpose of a terminal emulator",
+        "finish-args-unnecessary-xdg-config-wezterm-rw-access": "required to access host configs, repos, workspaces and so on. https://github.com/flathub-infra/flatpak-builder-lint/issues/270",
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "org.winehq.Wine": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "toplevel-unnecessary-branch": "Wine uses a custom branch following runtime branch for historical reasons"
+    },
+    "org.wireshark.Wireshark": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
     "org.wxhexeditor.wxHexEditor": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5659,6 +5938,24 @@
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-own-name-org.x.StatusIcon.warpinator": "Predates the linter rule"
     },
+    "org.xfce.mousepad": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.xfce.ristretto": {
+        "finish-args-arbitrary-dbus-access": "https://github.com/flathub/flathub/issues/2770",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.xonotic.Xonotic": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "org.zaproxy.ZAP": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "org.zim_wiki.Zim": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
     "org.zirael.bkchem.BKChem": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
@@ -5666,11 +5963,159 @@
         "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-own-name-wildcard-org.mozilla.zotero": "Predates the linter rule"
     },
+    "org.zrythm.Zrythm": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "page.codeberg.Imaginer.Imaginer": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "page.codeberg.JakobDev.jdAppStreamEdit": {
+        "finish-args-flatpak-spawn-access": "required for preview in Gnome Software"
+    },
+    "page.codeberg.JakobDev.jdDBusDebugger": {
+        "finish-args-arbitrary-dbus-access": "It's a D-Bus Debugger",
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "page.codeberg.JakobDev.jdFlatpakSnapshot": {
+        "finish-args-flatpak-spawn-access": "Needed to call flatpak to get some Information and check if a Flatpak is currently running",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needs access to the Flatpak directory",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
+    },
+    "page.codeberg.JakobDev.jdMacroPlayer": {
+        "finish-args-flatpak-spawn-access": "Run ydotoold on the Host",
+        "finish-args-host-tmp-access": "Predates the linter rule"
+    },
+    "page.codeberg.JakobDev.jdMinecraftLauncher": {
+        "finish-args-unnecessary-xdg-data-applications-create-access": "jdMinecraftLauncher creates .desktop files in share/applications",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "page.codeberg.JakobDev.jdPermissionStoreEdit": {
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needs acccess to xdg-data/flatpak/db"
+    },
+    "page.codeberg.JakobDev.jdProcessFileWatcher": {
+        "finish-args-flatpak-spawn-access": "Run strace on the Host",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Needs to read desktop files",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Needs to read desktop files",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule"
+    },
+    "page.codeberg.JakobDev.jdSimpleAutostart": {
+        "finish-args-unnecessary-xdg-config-autostart-create-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "the app predates this linter rule",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "Needs to read desktop files",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-autostart-filesystem-access": "Predates the linter rule"
+    },
+    "page.codeberg.JakobDev.jdSystemMonitor": {
+        "finish-args-flatpak-spawn-access": "Run the Daemon outside the Flatpak"
+    },
+    "page.codeberg.JakobDev.jdTextEdit": {
+        "finish-args-flatpak-spawn-access": "Neded to execute external commands",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "page.codeberg.cozyowl.OpaqueFiles": {
+        "finish-args-host-filesystem-access": "Needed to encrypt, decrypt or check files in HOME and on mounted filesystems (USB, Network, ...)"
+    },
+    "page.codeberg.dnkl.foot": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via host-spawn",
+        "finish-args-only-wayland": "this program doesn't have x11 support"
+    },
+    "page.codeberg.friedrich.DND-Dice-Roller": {
+        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme"
+    },
+    "page.codeberg.lazyt.ubpm": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "page.codeberg.libre_menu_editor.LibreMenuEditor": {
+        "finish-args-unnecessary-xdg-data-xdg-desktop-portal-ro-access": "for reading .desktop files and icons in xdg-data/xdg-desktop-portal",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "for reading .desktop files and symlink targets in xdg-data/flatpak",
+        "finish-args-unnecessary-xdg-data-applications-create-access": "for creating, reading, modifying, and deleting .desktop files in xdg-data/applications",
+        "finish-args-unnecessary-xdg-config-mimeapps.list-create-access": "for reading and updating mimetypes in xdg-config/mimeapps.list",
+        "finish-args-flatpak-spawn-access": "for reading environment variables on the host system",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "page.kramo.Cartridges": {
+        "finish-args-flatpak-spawn-access": "required to launch games on the host",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "access to xdg-data/flatpak/app and exports is needed to import games installed as user flatpaks",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "page.tesk.Refine": {
+        "finish-args-flatpak-spawn-access": "needed to access host dconf configuration",
+        "finish-args-unnecessary-xdg-config-dconf-rw-access": "needed to access host dconf configuration at launch time",
+        "finish-args-direct-dconf-path": "needed to access host dconf configuration",
+        "finish-args-dconf-talk-name": "needed to access host dconf configuration"
+    },
+    "party.supertux.supertuxparty": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "pm.mirko.Atoms": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
     "pro.vpup.vpuppr": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "re.sonny.Commit": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "re.sonny.Junction": {
+        "finish-args-flatpak-spawn-access": "required to launch apps",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "required to list apps",
+        "finish-args-unnecessary-xdg-data-applications-ro-access": "required to list apps",
+        "finish-args-flatpak-system-folder-access": "Predates the linter rule",
+        "finish-args-host-var-access": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "ro.fxdata.taskmonitor.viewer": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "rocks.koreader.KOReader": {
+        "flathub-json-automerge-enabled": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "rocks.syng.Syng": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
     "rs.ruffle.Ruffle": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "ru.linux_gaming.PortProton": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "ru.proninyaroslav.libretrack": {
+        "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Predates the linter rule"
+    },
+    "ru.sview.sView": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
+    },
+    "ru.yandex.Browser": {
+        "finish-args-dconf-talk-name": "Predates the linter rule",
+        "finish-args-direct-dconf-path": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "sa.sy.bluerecorder": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "se.cendio.tlclient": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "se.emijoh.mpw": {
+        "finish-args-not-defined": "It is a command line package"
+    },
+    "se.manyver.Manyverse": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
     },
     "se.sjoerd.GIScan": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
@@ -5678,553 +6123,112 @@
     "se.trixon.Mapollage": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "site.someones.Lonewolf": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "us.pixls.art.ART": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.audiostellar.AudioStellar": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.rescribe.rescribe": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "xyz.woxel.Woxel": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
-    },
-    "com.gitbutler.gitbutler": {
-        "finish-args-has-socket-gpg-agent": "Needed to sign Git commits with GPG",
-        "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
-        "finish-args-host-filesystem-access": "Needed to access Git repositories outside the sandbox",
-        "finish-args-own-name-com.gitbutler.app": "Needed for D-Bus service registration"
-    },
-    "com.nomachine.nxplayer": {
-        "finish-args-ssh-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "de.capypara.FieldMonitor": {
-        "finish-args-ssh-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.gnome.seahorse.Application": {
-        "finish-args-ssh-filesystem-access": "Predates the linter rule",
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
-    },
-    "org.virt_manager.virt-manager": {
-        "finish-args-ssh-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
-        "finish-args-own-name-org.virt-manager.virt-manager": "Predates the linter rule"
-    },
-    "com.bktus.gpgfrontend": {
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
-    },
-    "com.konstantintutsch.Lock": {
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule"
-    },
-    "org.gajim.Gajim": {
-        "finish-args-gnupg-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.giantpinkrobots.varia": {
-        "finish-args-autostart-filesystem-access": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule",
-        "finish-args-own-name-io.github.giantpinkrobots.varia-tray": "Predates the linter rule"
-    },
-    "info.cemu.Cemu": {
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.hedge_dev.hedgemodmanager": {
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "org.garudalinux.firedragon": {
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.mozilla.firedragon": "Predates the linter rule",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "Needed for Breeze, etc. to use their colour scheme - upstream Firefox permission"
-    },
-    "org.kde.angelfish": {
-        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
-    },
-    "app.logorrr.LogoRRR": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "app.xemu.xemu": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.virustotal.VirusTotalUploader": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "de.leopoldluley.Clapgrep": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "dev.levz.TinyImageFinder": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.jorchube.monitorets": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.shiiion.primehack": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.gitlab.floodlight.Presenter": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.bino3d.bino": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.equeim.Tremotesf": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.flycast.Flycast": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.love2d.love2d": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "rocks.syng.Syng": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "ru.sview.sView": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "uk.co.electronstudio.ComicReaderUltimate": {
-        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
-    },
-    "ch.x29a.playitslowly": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.carpeludum.KegaFusion": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.corsixth.corsixth": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.retrodev.blastem": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "com.super_productivity.SuperProductivity": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "dev.paullee.scraterpreter.Scrape": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.KangLin.RabbitRemoteControl": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.github.btpf.alexandria": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.mihnea_radulescu.imagefanreloaded": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.mpc_qt.mpc-qt": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
-        "finish-args-contains-both-x11-and-wayland": "The app supports both X11 and Wayland through a Tweaks setting"
-    },
-    "io.github.punesemu.puNES": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.ryubing.Ryujinx": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.troyeguo.koodo-reader": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.freedesktop.GstDebugViewer": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Evince": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-org.gnome.evince": "Predates the linter rule",
-        "finish-args-own-name-org.gnome.evince.Daemon": "Predates the linter rule"
-    },
-    "org.gnome.NautilusPreviewer": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.gnome.Papers": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.kde.arianna": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.nuspell.Nuspell": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "org.wireshark.Wireshark": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "ro.fxdata.taskmonitor.viewer": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "uk.org.zint.zint-qt": {
-        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
-    },
-    "io.github.tobagin.secrets": {
-        "finish-args-gnupg-filesystem-access": "Used for creating gpg keys within the password manager.",
+    "sh.loft.devpod": {
+        "finish-args-flatpak-spawn-access": "Required for host shell access",
+        "finish-args-home-filesystem-access": "Predates the linter rule",
         "finish-args-has-socket-gpg-agent": "Predates the linter rule",
         "finish-args-has-socket-ssh-auth": "Predates the linter rule"
     },
-    "io.github.tobagin.keysmith": {
-        "finish-args-ssh-filesystem-access": "Used for creating/saving ssh keys within the application."
+    "site.someones.Lonewolf": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.rimsort.RimSort": {
-        "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the workshop rimworld file in Steam"
+    "space.fips.Fips": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
-    "uk.co.cappsy.Tesseract": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
+    "space.nouspiro.tenmon": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "page.codeberg.friedrich.DND-Dice-Roller": {
-        "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme"
+    "studio.assetmanager.ams": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
     },
-    "com.binarynonsense.acbr": {
-        "finish-args-home-filesystem-access": "As a reader and converter of comic book files, with an integrated file explorer, access to the home directory is required for some of the application's core features."
+    "studio.kx.carla": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     },
-    "io.github.pol_rivero.github-desktop-plus": {
-        "finish-args-has-socket-ssh-auth": "Needed to clone repositories using SSH.",
-        "finish-args-has-socket-gpg-agent": "Needed to sign commits with GPG.",
-        "finish-args-host-filesystem-access": "Needed to read and modify files in git repos outside of sandbox.",
-        "finish-args-flatpak-system-folder-access": "Needed to check which text editors the user has installed as flatpaks.",
-        "finish-args-flatpak-spawn-access": "Needed to spawn external text editors and terminals."
-    },
-    "im.dino.Dino": {
-        "finish-args-has-socket-gpg-agent": "Predates the linter rule"
-    },
-    "com.devolutions.remotedesktopmanager": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.kgurgul.cpuinfo": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.termius.Termius": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "dev.k8slens.OpenLens": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule",
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.beekeeperstudio.Studio": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.github.kalaksi.Lightkeeper": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "io.github.subhra74.Muon": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.mosh.mosh": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "org.virt_manager.virt-viewer": {
-        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
-    },
-    "com.vkhitrin.cosmicding": {
-        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
-    },
-    "org.easycoding.TunedSwitcher": {
-        "finish-args-systemd1-system-talk-name": "Predates the linter rule"
-    },
-    "org.jitsi.jitsi-meet": {
-        "finish-args-login1-talk-name": "Predates the linter rule"
-    },
-    "app.drey.Warp": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.microsoft.AzureStorageExplorer": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "dev.aa55.yetty": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.dgsasha.Remembrance": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.pwr_solaar.solaar": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "io.github.streetpea.Chiaki4deck": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "net.jami.Jami": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.freedesktop.fwupd": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.Firmware": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.GTG": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.gnome.Todo": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "org.sabnzbd.sabnzbd": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "tv.kodi.Kodi": {
-        "finish-args-login1-system-talk-name": "Predates the linter rule"
-    },
-    "com.pixelomer.ShijimaQt": {
-        "finish-args-kwin-talk-name": "Predates the linter rule"
-    },
-    "org.dpsoftware.FireflyLuciferin": {
-        "finish-args-kwin-talk-name": "Predates the linter rule"
-    },
-    "io.github.microgamercz.piki": {
-        "finish-args-plasmashell-talk-name": "Predates the linter rule"
-    },
-    "app.zen_browser.zen": {
-        "finish-args-own-name-wildcard-org.mozilla.zen": "Predates the linter rule"
-    },
-    "com.gopeed.Gopeed": {
-        "finish-args-own-name-com.gopeed.gopeed": "Predates the linter rule"
-    },
-    "com.humatarayici.od": {
-        "finish-args-own-name-wildcard-org.mozilla.huma": "Predates the linter rule"
-    },
-    "info.mumble.Mumble": {
-        "finish-args-own-name-net.sourceforge.mumble.mumble": "Predates the linter rule"
-    },
-    "io.github.efogdev.mpris-timer": {
-        "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Predates the linter rule",
-        "finish-args-own-name-org.kde.StatusNotifierItem-3-1": "Predates the linter rule"
-    },
-    "io.github.insilmaril.vym": {
-        "finish-args-own-name-org.insilmaril.vym-2": "Predates the linter rule"
-    },
-    "net.sourceforge.artha.Artha": {
-        "finish-args-own-name-org.artha.unique": "Predates the linter rule"
-    },
-    "net.waterfox.waterfox": {
-        "finish-args-own-name-wildcard-org.mozilla.waterfox": "Predates the linter rule"
-    },
-    "org.clementine_player.Clementine": {
-        "finish-args-own-name-org.kde.StatusNotifierItem-2-2": "Predates the linter rule"
-    },
-    "org.gmusicbrowser.gmusicbrowser": {
-        "finish-args-own-name-org.gmusicbrowser": "Predates the linter rule"
-    },
-    "org.gpodder.gpodder-adaptive": {
-        "finish-args-own-name-wildcard-org.gpodder": "Predates the linter rule"
-    },
-    "org.gtimelog.GTimeLog": {
-        "finish-args-own-name-org.gtimelog": "Predates the linter rule"
-    },
-    "org.kde.akregator": {
-        "finish-args-own-name-org.freedesktop.Akonadi": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.freedesktop.Akonadi": "Predates the linter rule",
-        "finish-args-own-name-org.kde.accountwizard": "Predates the linter rule",
-        "finish-args-own-name-org.kde.kaddressbook": "Predates the linter rule",
-        "finish-args-own-name-wildcard-org.kde.pim": "Predates the linter rule",
-        "finish-args-own-name-org.kde.pimsettingsexporter": "Predates the linter rule"
-    },
-    "org.kde.kclock": {
-        "finish-args-own-name-org.kde.kclockd": "Predates the linter rule"
-    },
-    "ru.proninyaroslav.libretrack": {
-        "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Predates the linter rule"
-    },
-    "org.mozilla.firefox": {
-        "finish-args-own-name-wildcard-org.mozilla.firefox_beta": "Predates the linter rule"
-    },
-    "life.bolls.bolls": {
-        "finish-args-full-home-config-access": "Predates the linter rule"
-    },
-    "io.github.shonubot.Spruce": {
-        "finish-args-flatpak-spawn-access": "Allows calling host tools for size checks and safe deletions, restricted to user-selected targets."
-    },
-    "de.gonicus.gonnect": {
-        "finish-args-unnecessary-xdg-data-evolution-ro-access": "EDS exposes avatar images here, and GOnnect likes to display them on incoming calls."
-    },
-    "org.indii.mendingwall": {
-        "finish-args-unnecessary-xdg-config-autostart-create-access": "install autostart programs to restore themes on desktop login, with additional features required beyond those provided by the background portal",
-        "finish-args-unnecessary-xdg-config-plasma-workspace-create-access": "install autostart programs to restore themes on desktop login, which run earlier in the startup process for KDE",
-        "finish-args-direct-dconf-path": "save and restore desktop environment theme configuration stored in GSettings dconf backend",
-        "finish-args-unnecessary-xdg-config-dconf-rw-access": "save and restore desktop environment theme configuration stored in GSettings dconf backend",
-        "finish-args-dconf-talk-name": "save and restore desktop environment theme configuration stored in GSettings dconf backend",
-        "finish-args-arbitrary-xdg-config-rw-access": "save and restore desktop environment theme configuration stored in configuration files",
-        "finish-args-unnecessary-xdg-config-gtk-3.0-create-access": "save and restore desktop environment theme configuration stored in configuration files",
-        "finish-args-unnecessary-xdg-config-gtk-4.0-create-access": "save and restore desktop environment theme configuration stored in configuration files",
-        "finish-args-unnecessary-xdg-config-xsettingsd-create-access": "save and restore desktop environment theme configuration stored in configuration files",
-        "finish-args-host-var-access": "read .desktop files of applications installed on the system",
-        "finish-args-flatpak-system-folder-access": "read .desktop files of Flatpak applications installed on the system",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "read .desktop files of Flatpak applications installed by the user",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "batch save updated .desktop files to organise applications between the menus of different desktop environments"
-    },
-    "io.github.Querz.mcaselector": {
-        "finish-args-flatpak-appdata-folder-access": "To open and edit Minecraft worlds files under launchers packages as Flatpak applications"
-    },
-    "net.blumia.pineapple-steam-recording-exporter": {
-        "finish-args-flatpak-appdata-folder-access": "To access and export video recordings under the Steam client packaged as Flatpak applications"
-    },
-    "one.k8ie.Identities": {
-        "finish-args-has-socket-gpg-agent": "Needs to be able to use your host's GPG agent to decrypt password store entries",
-        "finish-args-gnupg-filesystem-access": "Due to how GPG handles working with a remote agent, the Flatpak's GPG needs to know which public keys are available on the \"remote\" host - see https://wiki.gnupg.org/AgentForwarding"
-    },
-    "org.kde.discover": {
-        "finish-args-flatpak-system-folder-access": "Needs access to system-wide flatpak installation so that it can manage them",
-        "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needs access to user-wide flatpak installation so that it can manage them",
-        "finish-args-flatpak-system-talk-name": "Talks to the system-wide flatpak dbus address in order to query existence of flatpaks and send installation commands to it",
-        "finish-args-flatpak-appdata-folder-access": "Needs access to settings and user data of other apps ",
-        "finish-args-flatpak-spawn-access": "Runs host binaries in order to successfully install apps"
-    },
-    "it.mq1.TinyWiiBackupManager": {
-        "finish-args-host-filesystem-access": "Used for loading the rom dumps from anywhere in the home directory or from a drive, and for transferring them to the Wii drive."
-    },
-    "org.kde.hana": {
-        "finish-args-home-filesystem-access": "Needs to save images in an user defined folder"
-    },
-    "io.github.d0ksan8.zen-app-manager": {
-        "finish-args-unnecessary-xdg-config-autostart-rw-access": "Startup manager needs direct access to manage autostart entries"
+    "surf.deckr.deckr": {
+        "appid-url-not-reachable": "Request is returning 403, https://github.com/flathub/flathub/pull/5529#issuecomment-2325455509"
     },
     "tech.keyforge.keyforge_master": {
         "finish-args-flatpak-spawn-access": "Required to run 'udevadm' on the host system via flatpak-spawn for USB keyboard device detection and enumeration"
     },
-    "com.bilingify.readest": {
-        "finish-args-own-name-org.com_bilingify_readest.SingleInstance": "Required because Tauri hard-codes DBus service names and replaces dots with underscores"
+    "tv.kodi.Kodi": {
+        "finish-args-login1-system-talk-name": "Predates the linter rule"
     },
-    "io.github.jmberesford.Retrom": {
-        "finish-args-flatpak-spawn-access": "the app is a launcher for other arbitrary applications configured by the user and requires the ability to spawn external processes on the host",
-        "finish-args-home-filesystem-access": "many users place/install games and portable emulators/applications that Retrom must manage in arbitrary locations in the home directory"
+    "tv.plex.PlexHTPC": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
-    "io.sourceforge.xtrkcad_fork.xtrkcad": {
-        "finish-args-home-filesystem-access": "Needed since the app reads/writes track plans stored anywhere on users home directory"
+    "ua.org.brezblock.q4wine": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
     },
-    "org.kde.atlantik": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.bomber": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.bovo": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.granatier": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kapman": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.katomic": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kblackbox": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kblocks": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kbounce": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kbreakout": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kdiamond": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kfourinline": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kgoldrunner": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kigo": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.killbots": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kiriki": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kjumpingcube": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.klickety": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.klines": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kmahjongg": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kmines": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.knavalbattle": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.knetwalk": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.knights": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kolf": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kollision": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.konquest": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kpat": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kreversi": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kshisen": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.ksirk": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.ksnakeduel": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.ksquares": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.ksudoku": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.ktuberling": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.kubrick": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.lskat": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.palapeli": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "org.kde.picmi": {
-        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
-    },
-    "eu.binjr.binjr": {
-        "finish-args-host-filesystem-access": "Application loads source files (logs, csv, rrd) from any location the user requires and writes saved workspace in arbitrary location in user's home or and mounted filesystems"
-    },
-    "dev.tony4.subscribi": {
+    "uk.co.cappsy.Tesseract": {
         "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
     },
-    "io.github.epasveer.seer": {
-        "finish-args-flatpak-spawn-access": "Seer needs to launch the gdb binary that is on the host system.",
-        "finish-args-host-filesystem-access": "Seer needs to access the executable being debugged on the host system. Plus source files."
+    "uk.co.electronstudio.ComicReaderUltimate": {
+        "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
-    "org.pvermeer.WebAppHub": {
-        "finish-args-flatpak-system-folder-access": "Used to fetch the icons of system installed flatpak browsers.",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Used to fetch the icons of user installed flatpak browsers.",
-        "finish-args-flatpak-spawn-access": "This is needed to fetch installed browser information and to run the created Web App from this application.",
-        "finish-args-unnecessary-xdg-data-applications-create-access": "Used to create and delete owned desktop files for web apps.",
-        "finish-args-flatpak-appdata-folder-access": "Used to create isolated profile folder for flatpak browsers. For some flatpak browsers it's necessary to create a directory in their sandbox for profile isolation. For some browsers it's used to update the isolated profile config for a minimal ui."
+    "uk.jnthn.backgammony": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "uk.me.doof.Lander": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "uk.org.greenend.chiark.sgtatham.putty": {
+        "appid-too-many-components-for-app": "Predates the linter rule",
+        "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+    },
+    "uk.org.greenend.chiark.sgtatham.puzzles": {
+        "appid-too-many-components-for-app": "Predates the linter rule"
+    },
+    "uk.org.zint.zint-qt": {
+        "finish-args-home-ro-filesystem-access": "Predates the linter rule"
+    },
+    "us.pixls.art.ART": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "us.zoom.Zoom": {
+        "finish-args-own-name-wildcard-org.kde": "Initial import, outdated Qt, still uses legacy StatusNotifier implementation",
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "website.i2pd.i2pd": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "work.openpaper.Paperwork": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "finish-args-host-filesystem-access": "Predates the linter rule",
+        "finish-args-own-name-work.openpaper.paperwork": "Predates the linter rule"
+    },
+    "xyz.armcord.ArmCord": {
+        "flathub-json-automerge-enabled": "Predates the linter rule"
+    },
+    "xyz.audiostellar.AudioStellar": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "xyz.hyperplay.HyperPlay": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+        "finish-args-flatpak-appdata-folder-access": "Predates the linter rule",
+        "finish-args-desktopfile-filesystem-access": "Predates the linter rule"
+    },
+    "xyz.rescribe.rescribe": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
+    },
+    "xyz.rust4diva.Rust4Diva": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "xyz.slothlife.Jogger": {
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+    },
+    "xyz.splashmapper.Splash": {
+        "finish-args-host-filesystem-access": "Predates the linter rule"
+    },
+    "xyz.stuerz.BilligSweeper": {
+        "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+    },
+    "xyz.tytanium.DoorKnocker": {
+        "finish-args-flatpak-spawn-access": "Required to get/check xdg-desktop-portal version"
+    },
+    "xyz.woxel.Woxel": {
+        "finish-args-home-filesystem-access": "Predates the linter rule"
     }
 }


### PR DESCRIPTION
## Summary
RustConn is an SSH/RDP/VNC/SPICE connection manager for Linux (GTK4/libadwaita).

## Requested Exceptions

### `finish-args-ssh-filesystem-access`
RustConn needs read-only access to `~/.ssh` to load user's existing SSH keys and config files for SSH connections. This is essential for the app's core functionality as an SSH client.

### `finish-args-has-socket-ssh-auth`
Required for SSH agent forwarding to enable key-based authentication for SSH connections without re-entering passphrases.

## Similar Apps with These Exceptions
- `io.github.mfat.sshpilot` - SSH client
- `io.github.BuddySirJava.SSH-Studio` - SSH connection editor
- `com.github.muriloventuroso.easyssh` - SSH client
- `com.github.alecaddd.sequeler` - Database client with SSH tunneling

## Links
- GitHub: https://github.com/totoshko88/RustConn
- Flathub PR: https://github.com/flathub/flathub/pull/7401