### PR TITLE
Add exception for io.github.lephotographelibre.BlueNotebook (home fil…

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6209,5 +6209,8 @@
         "finish-args-flatpak-spawn-access": "This is needed to fetch installed browser information and to run the created Web App from this application.",
         "finish-args-unnecessary-xdg-data-applications-create-access": "Used to create and delete owned desktop files for web apps.",
         "finish-args-flatpak-appdata-folder-access": "Used to create isolated profile folder for flatpak browsers. For some flatpak browsers it's necessary to create a directory in their sandbox for profile isolation. For some browsers it's used to update the isolated profile config for a minimal ui."
+    },
+    "io.github.lephotographelibre.BlueNotebook": {
+        "finish-args-home-filesystem-access": "Access to files in the user's directory is required, as this is common for an editor to include images or opening  documents such as EPUB or PDF files."
     }
 }


### PR DESCRIPTION
…esystem access)

Access to files in the user's directory is required, as this is common for an **editor** to include images or opening  documents such as EPUB or PDF files.