### PR TITLE
Update exceptions.json for org.kiwix.desktop

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "org.kiwix.desktop": {
+        "finish-args-host-ro-filesystem-access": "The app is a ZIM file reader intended to open (but not write) ZIM files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations."
+    },
     "io.gitlab.zulfian1732.jollpi-text-editor": {
         "finish-args-host-filesystem-access": "The app is a text editor intended to open and edit arbitrary files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations, similar to other text editors."
     },


### PR DESCRIPTION
This is necessary to allow the new release `2.5.0` of Kiwix to pass the linting. See https://github.com/flathub/org.kiwix.desktop/pull/16