### PR TITLE
Add exception for ai.opencode.opencode

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "ai.opencode.opencode": {
+        "finish-args-home-filesystem-access": "Needed to access and modify projects outside the sandbox"
+    },
     "io.github.hakandundar34coding.system-monitoring-center": {
         "finish-args-flatpak-spawn-access": "The application is a system monitor. For monitoring and managing system, several commands (mostly ls, cat, systemctl, renice, ps, nmcli) are run on host OS"
     },


### PR DESCRIPTION
The bundled `opencode` CLI binary requires host filesystem access to read and write project files.

For flathub/flathub#7489