### PR TITLE
Add exception for org.vanillaos.ApxGUI

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "org.vanillaos.ApxGUI": {
+        "finish-args-flatpak-spawn-access": "Needed to execute Distrobox commands on the host"
+    },
     "io.gitlab.zulfian1732.jollpi-text-editor": {
         "finish-args-host-filesystem-access": "The app is a text editor intended to open and edit arbitrary files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations, similar to other text editors."
     },


### PR DESCRIPTION
Apx requires access to Distrobox on the host system to manage containers.

For flathub/flathub#7515