### PR TITLE
Add exception for io.github.cosmic_utils.camera

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3741,6 +3741,9 @@
     "com.francescogaglione.cosmicmoney": {
         "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
     },
+    "io.github.cosmic_utils.camera": {
+        "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read the system theme and write app configuration files"
+    },
     "io.github.cosmic_utils.Examine": {
         "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
     },


### PR DESCRIPTION
## Summary
Add linter exception for COSMIC Camera app:
- `finish-args-unnecessary-xdg-config-cosmic-rw-access`: Required to read the system theme and write app configuration files

This is a COSMIC desktop app that needs access to `xdg-config/cosmic` for theme detection and storing app configuration.