### PR TITLE
Add linter exception for io.github.sourcegit_scm.sourcegit (soon on flathub)

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6190,5 +6190,8 @@
         "finish-args-flatpak-spawn-access": "This is needed to fetch installed browser information and to run the created Web App from this application.",
         "finish-args-unnecessary-xdg-data-applications-create-access": "Used to create and delete owned desktop files for web apps.",
         "finish-args-flatpak-appdata-folder-access": "Used to create isolated profile folder for flatpak browsers. For some flatpak browsers it's necessary to create a directory in their sandbox for profile isolation. For some browsers it's used to update the isolated profile config for a minimal ui."
+    },
+    "io.github.sourcegit_scm.sourcegit": {
+        "finish-args-gnupg-filesystem-access": "SourceGit provides ability to sign commits using gnupg, while the Flatpak's GPG needs to know which public keys are available - see https://wiki.gnupg.org/AgentForwarding"
     }
 }


### PR DESCRIPTION
App provides ability to sign commits using gnupg, while the Flatpak's GPG needs to know which public keys are available - see https://wiki.gnupg.org/AgentForwarding.

App not yet on flathub, but will be soon.