### PR TITLE
Add exception for com.infinipaint.infinipaint to read/write to home directory

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "com.infinipaint.infinipaint": {
+        "finish-args-home-filesystem-access": "Needed to save project files outside of standard directories."
+    },
     "org.vanillaos.ApxGUI": {
         "finish-args-flatpak-spawn-access": "Needed to execute Distrobox commands on the host"
     },


### PR DESCRIPTION
Some users have run into issues saving to directories outside of Desktop/Documents. I am aware that these permissions can be changed using something like Flatseal, but if possible I'd like to have permissions for the home directory by default so that it could lead to less confusion for users who are unaware of Flatpak permissions.