### PR TITLE
Add exception for com.sublimehq.SublimeText

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,7 @@
 {
+    "com.sublimehq.SublimeText": {
+        "finish-args-host-filesystem-access": "The app is a text editor intended to open and edit arbitrary files on the user's system. Host filesystem access is required to allow opening files outside of sandboxed locations, similar to other text editors."
+    },
     "org.vanillaos.ApxGUI": {
         "finish-args-flatpak-spawn-access": "Needed to execute Distrobox commands on the host"
     },


### PR DESCRIPTION
Hi ! 

This is for the new flatpak for Sublime Text (4) ! 

Since Sublime Text is a text editor, it would be the most convenient for the user for it to have access to their files normally.   
I've copied the exception from jollpi-text-editor since it has same goal (and has a very good summary of the situation). 

Have a nice day ! :D