### PR TITLE
manifest: emit a warning for tag without commit

### DIFF
--- a/flatpak_builder_lint/checks/modules.py
+++ b/flatpak_builder_lint/checks/modules.py
@@ -54,6 +54,10 @@ class ModuleCheck(Check):
                 self.errors.add(f"module-{module_name}-source-git-no-tag-commit-branch")
                 return
 
+            if tag and not commit:
+                self.warnings.add(f"module-{module_name}-source-git-no-commit-with-tag")
+                return
+
             if branch and not _is_git_commit_hash(branch):
                 self.errors.add(f"module-{module_name}-source-git-branch")
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -354,6 +354,13 @@ def test_manifest_modules_git_disallowed() -> None:
     for e in errors:
         assert e in found_errors
 
+    warnings = {
+        "module-module3-source-git-no-commit-with-tag",
+    }
+    found_warnings = set(ret["warnings"])
+    for w in warnings:
+        assert w in found_warnings
+
 
 def test_manifest_exceptions() -> None:
     ret = run_checks("tests/manifests/exceptions.json", enable_exceptions=True)


### PR DESCRIPTION
It's just a warning for now, but with all the retagging I see happening it's important for reproducibility.