### PR TITLE
chore: enable access to xdg autostart path to enable autostart

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4137,7 +4137,8 @@
     },
     "com.nextcloud.desktopclient.nextcloud": {
         "finish-args-host-filesystem-access": "Predates the linter rule",
-        "finish-args-own-name-com.nextcloudgmbh.Nextcloud": "Predates the linter rule"
+        "finish-args-own-name-com.nextcloudgmbh.Nextcloud": "Predates the linter rule",
+        "finish-args-xdg-config-autostart-rw-access": "Required for autostart support until portal is properly supported"
     },
     "com.nitrokey.nitrokey-app": {
         "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
the desktop files client for Nextcloud knows how to generate an autostart file to use the flatpak package

for this to work, an exception is needed

long term plan is to have proper support for the appropriate portal