### PR TITLE
Allow io.github.strikerx3.ymir to access host read only and home

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6173,6 +6173,6 @@
     },
     "io.github.strikerx3.ymir": {
         "finish-args-host-ro-filesystem-access": "Required to load Roms correctly which where split into multiple bin tracks.",
-        "finish-args-home-filesystem-access": "Required in order to allow writing config files and custom files for loading of Sega Saturn IPL's."
+        "finish-args-home-filesystem-access": "Required in order to allow writing config files and custom files for loading of Sega Saturn IPL's. Also needed to load external game files and saved games folders"
     }
 }


### PR DESCRIPTION
finish-args-host-ro-filesystem-access
This is used by ymir to allow users to load split bin files which on some systems, for example like the SteamDeck were the roms are on a SD Cards and not mounted in the users home folder.

finish-args-home-filesystem-access
This is wanted by the maintainer of the project to allow users to save custom configurations and later load them on the fly. These are not used by the config folder and more to be shared in the community.

Merge is in Response to this Pull by the maintainer 
https://github.com/flathub/io.github.strikerx3.ymir/pull/10

Issue was documented by Maintainer in Repository already
https://github.com/StrikerX3/Ymir/commit/f9d3ae80915ac77dd009cebb492cb073de51e2f2
Most comments about users wanting ro on host on discord by steamdeck users.