### PR TITLE
Add X11 and Wayland socket exception for UnityHub

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1229,6 +1229,7 @@
     },
     "com.unity.UnityHub": {
         "finish-args-flatpak-spawn-access": "needed to spawn the flatpaked version of vscode from the editor",
+        "finish-args-contains-both-x11-and-wayland": "x11 is needed to start the editor from the hub with > 3.12.0, wayland is necessary to start the hub (which starts the editor); with just fallback-x11 the editor fails to start entirely",
         "finish-args-host-filesystem-access": "Predates the linter rule",
         "finish-args-login1-system-talk-name": "Predates the linter rule"
     },


### PR DESCRIPTION
Open to alternative suggestions but looks like Unity decided to upgrade the Hub to newer Electron versions after 3.12.0 that now need the Wayland socket, but combining it with `fallback-x11` instead of `x11` breaks the editor (which is started from the hub) and projects won't open any more.

It's a proprietary codebase and the Unity Editor (unfortunately) probably isn't getting native Wayland support soon.

See also https://github.com/flathub/com.unity.UnityHub/pull/171#issuecomment-3824193033 for details.