### PR TITLE
Add exceptions for io.github.sourcegit_scm.sourcegit

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6174,7 +6174,6 @@
     "io.github.sourcegit_scm.sourcegit": {
         "finish-args-has-socket-gpg-agent": "Needed to sign Git commits with GPG",
         "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
-        "finish-args-unnecessary-xdg-config-git-create-access": "Needed to read git config",
-        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it and other symlinks"
+        "finish-args-unnecessary-xdg-config-git-create-access": "Needed to read git config"
     }
 }


### PR DESCRIPTION
# GPG and SSH agent access

SourceGit is a Open-source & Free Git GUI Client

SSH Agent permission is used to clone git repos.
GPG Agent permission is used to sign commits.
xdg-config-git-create-access is to read/write git config
Flatpak Spawn will be used to launch terminals and IDEs (later)
Currently it is required for gpg signing

https://github.com/flathub/flathub/pull/7714
