### PR TITLE
Add exception for `io.github.qarmin.krokiet`

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6175,5 +6175,8 @@
         "finish-args-has-socket-gpg-agent": "Needed to sign Git commits with GPG",
         "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
         "finish-args-unnecessary-xdg-config-git-create-access": "Needed to read git config"
+    },
+    "io.github.qarmin.krokiet": {
+        "finish-args-host-filesystem-access": "The app contains multiple file-based tools (e.g., finding duplicates, identifying largest files, checking invalid extensions). These functions require access to arbitrary paths, including home directories and external locations and some users use them on system files."
     }
 }


### PR DESCRIPTION
Flathub PR - https://github.com/flathub/flathub/pull/7717

Krokiet contains multiple tools, for finding:
- Duplicates
- Similar videos, audio, images
- Empty files/folders
- Temporary files
- Invalid symlinks
- Broken files
- Bad extensions

that allow users to process files on any arbitrary paths, typically within home directories or on external drives, but some users use them even on system files.