### PR TITLE
Add exceptions for io.github.totoshko88.RustConn

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5789,8 +5789,7 @@
     "io.github.totoshko88.RustConn": {
         "finish-args-ssh-filesystem-access": "Needed to manage SSH keys and configurations for connections",
         "finish-args-has-socket-ssh-auth": "Needed for SSH agent authentication",
-  	"finish-args-flatpak-spawn-access": "Required to launch host commands (xfreerdp, wlfreerdp, vncviewer, ssh, remote-viewer) for remote connections",
-  	"finish-args-unnecessary-xdg-config-rustconn-create-access": "Required for persistent storage of connection profiles and application settings"
+  	"finish-args-flatpak-spawn-access": "Required to launch host commands (xfreerdp, wlfreerdp, vncviewer, ssh, remote-viewer) for remote connections"
     },
     "io.github.rimsort.RimSort": {
         "finish-args-unnecessary-xdg-data-Steam-rw-access": "Required for reading and writing the workshop rimworld file in Steam"


### PR DESCRIPTION
## Summary
Add two new exceptions for RustConn (io.github.totoshko88.RustConn), a remote connection manager.

## New exceptions requested

| Exception | Reason |
|-----------|--------|
| `finish-args-flatpak-spawn-access` | Required to launch host commands (xfreerdp, wlfreerdp, vncviewer, ssh, remote-viewer) for remote connections |
| `finish-args-unnecessary-xdg-config-rustconn-create-access` | Required for persistent storage of connection profiles and application settings |

## Existing exceptions (with updated format)

| Exception | Reason |
|-----------|--------|
| `finish-args-has-socket-ssh-auth` | Needed for SSH agent authentication |
| `finish-args-ssh-filesystem-access` | Needed to manage SSH keys and configurations for connections |

## Links
- Flathub: https://flathub.org/apps/io.github.totoshko88.RustConn
- Source: https://github.com/totoshko88/RustConn