### PR TITLE
Add exceptions for com.one-ware.OneWare

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6173,7 +6173,7 @@
         "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
         "finish-args-unnecessary-xdg-config-git-create-access": "Needed to read git config"
     },
-    "com.one-ware.OneWare": {
+    "com.one_ware.OneWare": {
         "finish-args-flatpak-spawn-access": "Required to allow the restart app button work after updating or removing extensions"
     }
 }


### PR DESCRIPTION
Currently our Flatpak users can't restart their app automatically after updating plugins.
After doing some research, my guess is that there is no other way then calling flatpak-spawn.

My App has a restart functionality, which restarts the app for the user after updating/removing plugins.

<img width="548" height="161" alt="image" src="https://github.com/user-attachments/assets/a1b7bf5c-5018-4813-88b1-7012bc7a5fac" />
