### PR TITLE
Add exceptions for com.one_ware.OneWare

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4729,7 +4729,8 @@
         "finish-args-own-name-wildcard-org.freedesktop.ReserveDevice1": "Predates the linter rule"
     },
     "com.one_ware.OneWare": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-flatpak-spawn-access": "Required to allow the restart app button work after updating or removing extensions"
     },
     "com.openwall.John": {
         "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Currently our Flatpak users can't restart their app automatically after updating plugins.
After doing some research, my guess is that there is no other way then calling flatpak-spawn.

My App has a restart functionality, which restarts the app for the user after updating/removing plugins.

<img width="548" height="161" alt="image" src="https://github.com/user-attachments/assets/a1b7bf5c-5018-4813-88b1-7012bc7a5fac" />
