### PR TITLE
Add exceptions for fr.arnaudmichel.launcherstudio

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6219,5 +6219,8 @@
     },
     "com.moonlight_stream.Moonlight": {
         "finish-args-host-os-ro-filesystem-access": "Predates the linter rule"
+    },
+    "fr.arnaudmichel.launcherstudio": {
+        "finish-args-unnecessary-xdg-data-applications-create-access": "The core functionality of this app is to create and manage .desktop files (launchers) for the user."
     }
 }


### PR DESCRIPTION
The app is a desktop entry creator/editor, so it requires write access to xdg-data/applications. 

The main submission is [here](https://github.com/flathub/flathub/pull/7736).

`finish-args-unnecessary-xdg-data-applications-create-access` permission allows to creat, read, modify, and delete .desktop files in xdg-data/applications