### PR TITLE
exceptions: Allow automerge for more KDE games

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1879,7 +1879,8 @@
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "org.kde.blinken": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
     },
     "org.kde.cantor": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
@@ -1955,7 +1956,8 @@
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
     },
     "org.kde.khangman": {
-        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"
+        "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
+        "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
     },
     "org.kde.kig": {
         "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule"


### PR DESCRIPTION
Allow `automerge-flathubbot-prs` for more KDE Games to let the bot merge the PRs automatically for the projects:

- org.kde.blinken
- org.kde.khangman

KDE Games are low risk, low impact apps that are unlikely to break. Enabling auto-updates for those apps will free-up some time for the KDE team to look at the other apps which are more important.

See: https://github.com/flathub-infra/flatpak-builder-lint/pull/790