### PR TITLE
Add exceptions for fr.arnaudmichel.launcherstudio

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6204,7 +6204,9 @@
         "finish-args-host-os-ro-filesystem-access": "Predates the linter rule"
     },
     "fr.arnaudmichel.launcherstudio": {
-        "finish-args-unnecessary-xdg-data-applications-create-access": "The core functionality of this app is to create and manage .desktop files (launchers) for the user."
+        "finish-args-unnecessary-xdg-data-applications-create-access": "The core functionality of this app is to create and manage .desktop files (launchers) for the user.",
+        "finish-args-flatpak-system-folder-access": "Required to read .desktop files of Flatpak applications installed on the system to manage them.",
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files of Flatpak applications installed by the user to manage them."
     },
     "io.github.hkdb.Aerion": {
         "finish-args-login1-system-talk-name": "Aerion as an email client needs to detect system sleep/wake via logind to trigger immediate mail sync after resume"


### PR DESCRIPTION
This PR adds missing exceptions for `fr.arnaudmichel.launcherstudio` requested during the review process.

The initial exception PR (#888) has been merged, but the reviewer noted that two additional permissions were required to read Flatpak data.

**Related Submission:**
flathub/flathub#7736

**Exceptions added:**
- `finish-args-flatpak-system-folder-access`: Required to read system-wide installed Flatpaks.
- `finish-args-unnecessary-xdg-data-flatpak-ro-access`: Required to read user-installed Flatpaks.