### PR TITLE
Add exceptions for fr.arnaudmichel.launcherstudio

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6206,7 +6206,8 @@
     "fr.arnaudmichel.launcherstudio": {
         "finish-args-unnecessary-xdg-data-applications-create-access": "The core functionality of this app is to create and manage .desktop files (launchers) for the user.",
         "finish-args-flatpak-system-folder-access": "Required to read .desktop files of Flatpak applications installed on the system to manage them.",
-        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files of Flatpak applications installed by the user to manage them."
+        "finish-args-unnecessary-xdg-data-flatpak-ro-access": "Required to read .desktop files of Flatpak applications installed by the user to manage them.",
+        "finish-args-home-ro-filesystem-access": "Required to load application icons located in arbitrary paths within the user's home directory (e.g. ~/.local/share, AppImages, downloads)."
     },
     "io.github.hkdb.Aerion": {
         "finish-args-login1-system-talk-name": "Aerion as an email client needs to detect system sleep/wake via logind to trigger immediate mail sync after resume"


### PR DESCRIPTION
The initial exception PR (#888) has been merged, but after testing the [build](https://github.com/flathub/flathub/pull/7736#issuecomment-3877147753), I realized that icons and executables for many applications were missing. This is because many user apps (like AppImages or tools installed via JetBrains Toolbox) store their resources in arbitrary paths within `~/.local/share` or the home directory.

**Related Submission:** [flathub/flathub#7736](https://github.com/flathub/flathub/pull/7736)

**Exceptions added:**

-  `finish-args-home-ro-filesystem-access`: Required to load application icons located in arbitrary paths within the user's home directory (e.g. ~/.local/share, AppImages, downloads).