### PR TITLE
Add xdg data flatpak rw access for io.github.kolunmi.Bazaar

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -48,6 +48,7 @@
     "io.github.kolunmi.Bazaar": {
         "finish-args-flatpak-spawn-access": "Runs host binaries in order to successfully install and launch apps",
         "finish-args-flatpak-system-folder-access": "Needs access to system-wide flatpak installation so that it can manage them",
+        "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needs access to user-wide flatpak installation so it can manage them",
         "finish-args-flatpak-system-talk-name": "Talks to the system-wide flatpak dbus address in order to query existence of flatpaks and send installation commands to it",
         "finish-args-flatpak-appdata-folder-access": "Needs access to user data of other apps so that it can remove leftover data"
     },


### PR DESCRIPTION
We made it so users can see/remove already installed user-scope apps in the Flatpak version of our app. (We still haven't been able to fix the extra-data issue, so installation is still not available.)