### PR TITLE
Add X11 and Wayland socket exception for RustDesk

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4478,7 +4478,8 @@
         "finish-args-host-ro-filesystem-access": "Predates the linter rule"
     },
     "com.rustdesk.RustDesk": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
+        "finish-args-home-filesystem-access": "Predates the linter rule",
+        "finish-args-contains-both-x11-and-wayland": "x11 socket is required for cursor image capture on the controlled side, wayland socket is required for native wayland protocol support"
     },
     "com.scanoss.sbom-workbench": {
         "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Add `finish-args-contains-both-x11-and-wayland` exception for `com.rustdesk.RustDesk`. 

RustDesk requires the X11 socket for cursor image capture on the controlled side, and the Wayland socket for native Wayland protocol support (e.g. system shortcut inhibition).

See: https://github.com/rustdesk/rustdesk/pull/14302

This PR is blocked https://github.com/flathub/com.rustdesk.RustDesk/pull/31   