### PR TITLE
org.cubocore.CoreRenamer: changed filesystem access to host

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4996,7 +4996,7 @@
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.cubocore.CoreRenamer": {
-        "finish-args-host-filesystem-access": "Predates the linter rule"
+        "finish-args-host-filesystem-access": "Requires host filesystem access because renaming is technically a directory-level write operation; since the Flatpak file portal only grants access to individual files rather than their parent folders, the sandbox prevents the app from modifying the directory entry to finalize a name change."
     },
     "org.cubocore.CoreShot": {
         "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
org.cubocore.CoreRenamer is a batch file renamer. It gets files from file system and rename them. 

Currently any files outside of the home dir the renaming fails.

Because renaming a file is a directory operation—requiring the ability to modify the folder's entry list to swap names—and the portal provides no way to authorize directory-level changes based on a single file selection (as file selection dialog only gives access to that file) , the operation is blocked by the sandbox.

Also I think renaming files creats a new file, but as we only get file access only through the portals, not the dir, so when we want to save the new renamed file to the parent dir, it fails 

Granting host filesystem access solves this. Similar application has this access, like https://github.com/flathub/org.kde.krename

I have made a PR to do this in the repo also, https://github.com/flathub/org.cubocore.CoreRenamer/pull/11
