### PR TITLE
Add exception for appid-url-not-reachable on io.github.jalaucapstones.pacman-recreation

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5859,5 +5859,10 @@
     },
     "io.github.hkdb.Aerion": {
         "finish-args-login1-system-talk-name": "Aerion as an email client needs to detect system sleep/wake via logind to trigger immediate mail sync after resume"
+    },
+    {
+    "io.github.jalaucapstones.pacman-recreation": {
+        "appid-url-not-reachable": "The actual GitHub repo is https://github.com/JalaU-Capstones/pacman-recreation with capital letters and hyphen in username; lowercase variant does not exist but the domain is controlled by the developer."
     }
+}
 }


### PR DESCRIPTION
Add exception for appid-url-not-reachable on io.github.jalaucapstones.pacman-recreation

The linter derives https://github.com/jalaucapstones/pacman-recreation which 404s, but the real repo is https://github.com/JalaU-Capstones/pacman-recreation (capital letters and hyphen in username). The domain is fully controlled by me (Diego Alejandro / Code With Botina), so this is a false positive.

Thanks!