### PR TITLE
Restore exception for AbiWord

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4353,6 +4353,9 @@
     "codes.loers.Karlender": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
+    "com.abisource.AbiWord": {
+        "finish-args-home-filesystem-access": "Doesn't use portals"
+    },
     "com.bambulab.BambuStudio": {
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },


### PR DESCRIPTION
It was automatically removed in commit 67ebcaece4aa9cbf64633a209ab7b12d7551fc05 erroneously

See https://github.com/flathub/com.abisource.AbiWord/pull/49
and
https://github.com/flathub/com.abisource.AbiWord/pull/50