### PR TITLE
Add exception for fr.quentium.stacer

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5862,5 +5862,8 @@
     },
     "io.github.hkdb.Aerion": {
         "finish-args-login1-system-talk-name": "Aerion as an email client needs to detect system sleep/wake via logind to trigger immediate mail sync after resume"
+    },
+    "fr.quentium.stacer": {
+        "finish-args-unnecessary-xdg-config-autostart-rw-access": "Stacer needs access to manage user autostart entries in Startup Apps section of the app"
     }
 }


### PR DESCRIPTION
Stacer handles autostart for the user in a section of the app, it's only managed by user input.

Linked submission PR https://github.com/flathub/flathub/pull/7854