### PR TITLE
org.cubocore.CoreHunt: add host read access to find files

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4982,6 +4982,7 @@
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.cubocore.CoreHunt": {
+        "finish-args-host-ro-filesystem-access": "Able to read the filesystem to find files",
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.cubocore.CoreImage": {


### PR DESCRIPTION
org.cubocore.CoreHunt is a file search utility. It needs all file system read access to find the files that user wants.

Similar app like https://github.com/flathub/de.leopoldluley.Clapgrep requires this acces