### PR TITLE
added host access to org.cubocore.CoreFM

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4979,7 +4979,7 @@
         "finish-args-home-filesystem-access": "Predates the linter rule"
     },
     "org.cubocore.CoreFM": {
-        "finish-args-home-filesystem-access": "Predates the linter rule"
+        "finish-args-host-filesystem-access": "Requries host access to browse all the files in the entire filesystem."
     },
     "org.cubocore.CoreHunt": {
         "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
org.cubocore.CoreFM is a file manager and requires access to all the file system to able to browse all files.

only access to the run, mmt is not enough, as file manager it brakes the usability like viewing, making backup system files.