### PR TITLE
Add home access to c.cubocore.CoreGarage

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4975,6 +4975,9 @@
     "org.cubocore.CoreFM": {
         "finish-args-host-filesystem-access": "Requries host access to browse all the files in the entire filesystem."
     },
+    "cc.cubocore.CoreGarage": {
+        "finish-args-home-filesystem-access": "Accessing the cubocore apps shared setting file in ./home/config folder, and make it if has not been created yet."
+    },
     "org.cubocore.CoreHunt": {
         "finish-args-host-ro-filesystem-access": "Able to read the filesystem to find files",
         "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Project files -  https://gitlab.com/cubocore/coreapps/coregarage

This is a settings/ tweaks app for our suite of apps called coreapps. Around 13 apps already in the flathub, and this app will allow tweak some aspect of these apps using the shared config file placed in the .config/cubocore folder

I tried to have only access the .config/cubocore folder, but this is the issue.

In non-flatpak scenario, if the folder does not exist, coregarage makes that folder and saves the config file inside that folder.
In flatpak, now if i give only access to the .config/cubocore through the flatpak permission, the above task fails as the folder does not exist in a clean system.

also in a clean system the config folder does not exists, like postmarketOS.  then the app needs to create the .config folder also. and this requries the home folder access. 

this app also able to change the default app list for each filetype  in the mimeapps.list, located in home folder. so home folder access is needed.

I added the new exception with our other apps, sorted alphabetically. 