### PR TITLE
Add kwin-talk-name exception for io.github.alper_han.crossmacro

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5848,6 +5848,9 @@
         "finish-args-has-socket-ssh-auth": "Needed to clone Git repositories using SSH",
         "finish-args-unnecessary-xdg-config-git-create-access": "Needed to read git config"
     },
+    "io.github.alper_han.crossmacro": {
+        "finish-args-kwin-talk-name": "Required to talk to a KWin script for tracking cursor position on KDE Wayland"
+    },
     "com.moonlight_stream.Moonlight": {
         "finish-args-host-os-ro-filesystem-access": "Predates the linter rule"
     },


### PR DESCRIPTION
Required to talk to a KWin script for tracking cursor position on KDE Wayland.

CrossMacro uses KWin scripting over D-Bus (`org.kde.KWin`) in its KDE Wayland backend:
- https://github.com/alper-han/CrossMacro/blob/ac4216213d353c9ad622593b36521a46a9c55c7d/src/CrossMacro.Platform.Linux/DisplayServer/Wayland/KdePositionProvider.cs#L157
- https://github.com/alper-han/CrossMacro/blob/ac4216213d353c9ad622593b36521a46a9c55c7d/src/CrossMacro.Platform.Linux/DisplayServer/Wayland/KdePositionProvider.cs#L172

KDE-specific path is selected only on KDE compositor:
- https://github.com/alper-han/CrossMacro/blob/ac4216213d353c9ad622593b36521a46a9c55c7d/src/CrossMacro.Platform.Linux/Services/Factories/Selectors/KdePositionProviderSelector.cs#L13

Other environments use different backends/fallbacks.

Related Flathub submission:
https://github.com/flathub/flathub/pull/7889
