### PR TITLE
Add exceptions for io.github.ebkr.r2modman

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9018,5 +9018,11 @@
         "*": {
             "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"
         }
+    },
+    "io.github.ebkr.r2modman": {
+        "*": {
+            "finish-args-flatpak-spawn-access": "Required to launch Steam games on the Steam Deck when in game mode",
+            "finish-args-flatpak-appdata-folder-access": "Required to detect the Steam Flatpak and the games located in the default Steam library location"
+        }
     }
 }


### PR DESCRIPTION
If io.github.ebkr.r2modman is approved, please add the following exceptions:

- `finish-args-flatpak-spawn-access`, which is needed so the app can launch games on the Steam Deck while in game mode. In game mode, the desktop portals do not function, and the Steam protocol is not registered, so invoking the `steam.sh` script is needed.
- `finish-args-flatpak-appdata-folder-access`, which is needed so the app can locate the Steam Flatpak install (if it is being used), and the game library (in its default location).