### PR TITLE
Add exception for io.github.Faugus.faugus-launcher

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3526,7 +3526,7 @@
             "finish-args-contains-both-x11-and-wayland": "Without socket=X11 Winetricks doesn't work on Wayland and without socket=wayland the Wine Wayland driver doesn't work.",
             "finish-args-home-filesystem-access": "Predates the linter rule",
             "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Required by MangoHud to detect the settings file.",
-            "finish-args-arbitrary-dbus-access": "Required by umu-launcher to access the Steam Runtime's pressure-vessel."
+            "finish-args-own-name-wildcard-com.steampowered": "Required by umu-launcher to access the Steam Runtime's pressure-vessel."
         }
     },
     "io.github.Fndroid.clash_for_windows": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3525,7 +3525,8 @@
         "stable": {
             "finish-args-contains-both-x11-and-wayland": "Without socket=X11 Winetricks doesn't work on Wayland and without socket=wayland the Wine Wayland driver doesn't work.",
             "finish-args-home-filesystem-access": "Predates the linter rule",
-            "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Required for MangoHud to detect the settings file."
+            "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Required by MangoHud to detect the settings file.",
+            "finish-args-arbitrary-dbus-access": "Required by umu-launcher to access the Steam Runtime's pressure-vessel."
         }
     },
     "io.github.Fndroid.clash_for_windows": {


### PR DESCRIPTION
UMU-Launcher needs to connect to the Steam Runtime pressure-vessel via DBus in order to run multiple applications under the same prefix.
That's the recommended way to do so for debugging