### PR TITLE
Add exceptions for es.gob.afirma

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3193,6 +3193,12 @@
             "finish-args-flatpak-spawn-access": "the app predates this linter rule"
         }
     },
+    "es.gob.afirma": {
+        "stable": {
+            "finish-args-host-filesystem-access": "It must sign arbitrary documents from any location the user specifies, write the signed output back to those paths, and serve a local HTTPS server for browser integration with government web portals. Document paths cannot be predicted or restricted in advance, making broad filesystem access a functional requirement.",
+            "appid-url-not-reachable": "The app ID es.gob.afirma is used by upstream and cannot be changed. It follows the reverse-DNS convention for gob.es, a domain owned and operated by the Spanish Government, however the specific subdomain afirma.gob.es does not exist. The official upstream is published by the Spanish Government at https://firmaelectronica.gob.es/ciudadanos/descargas."
+        }
+    },
     "eu.betterbird.Betterbird": {
         "*": {
             "finish-args-gnupg-filesystem-access": "Predates the linter rule",


### PR DESCRIPTION
Flathub PR: https://github.com/flathub/flathub/pull/7673

AutoFirma is the official digital signature client published by the Spanish Government. It must sign arbitrary documents from any location the user specifies, write the signed output back to those paths, and serve a local HTTPS server for browser integration with government web portals. Document paths cannot be predicted or restricted in advance, making broad filesystem access a functional requirement. It does not use portals, sadly. 

The app ID `es.gob.afirma` is used by upstream and cannot be changed. It follows the reverse-DNS convention for `gob.es`, a domain owned and operated by the Spanish Government, however the specific subdomain `afirma.gob.es does not exist. The official upstream is published by the Spanish Government at https://firmaelectronica.gob.es/ciudadanos/descargas.