### PR TITLE
Add exception for io.github.rafaelfassi.QLogExplorer

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4541,8 +4541,7 @@
     },
     "io.github.rafaelfassi.QLogExplorer": {
         "stable": {
-            "finish-args-home-filesystem-access": "Predates the linter rule",
-            "finish-args-host-var-access": "Predates the linter rule"
+            "finish-args-host-ro-filesystem-access": "Depending on the distribution and the specific application, log files may be located in several different folders of the host"
         }
     },
     "io.github.randovania.Randovania": {


### PR DESCRIPTION
I have received some complaints that QLogExplorer is unable to open certain log files.
The reason is because those logs are not inside /var/log which is the only location outside home QLogExplorer has filesystem permission to read.

Different distros and applications may store logs in a variety different locations, and there is no way to predict all possible places the log files can be stored. Restricting the access to specific locations only makes the software less useful for developers, devops and system admins who are the target users for this application.