### PR TITLE
Add exceptions for io.github.traciges.asus-hub

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3627,6 +3627,15 @@
             "finish-args-unnecessary-xdg-data-dolphin-emu-rw-access": "this program needs to be able to read and modify host Dolphin Mii and game/mod data files"
         }
     },
+    "io.github.traciges.asus-hub": {
+        "stable": {
+            "finish-args-has-dev-input": "Required for evdev input device access to detect touchpad gestures on ASUS laptops",
+            "finish-args-kwin-talk-name": "Required for KWin D-Bus integration to query active window state on KDE Plasma",
+            "finish-args-plasmashell-talk-name": "Required for Plasma Shell D-Bus access to display notifications and interact with the desktop",
+            "finish-args-own-name-org.kde.StatusNotifierItem-2-1": "Required to register a system tray icon via the StatusNotifierItem protocol",
+            "finish-args-flatpak-spawn-access": "Required for flatpak-spawn --host to apply hardware settings (fan curves, power profiles) via asusd/supergfxctl on the host"
+        }
+    },
     "io.github.TransmissionRemoteGtk": {
         "stable": {
             "appid-code-hosting-too-few-components": "app-id predates this linter rule"


### PR DESCRIPTION
Asus Hub is an unofficial, open-source Linux alternative to the MyASUS app for ASUS laptops. Just like MyASUS on Windows, it brings all ASUS-specific hardware controls into one place: battery care, fan profiles, GPU switching, OLED care, color profiles, keyboard backlight, audio profiles, and touchpad gesture configuration - all in a native GTK4 interface.

Flathub PR: https://github.com/flathub/flathub/pull/8383

  ### Exceptions

  **`finish-args-has-dev-input`**
  The app needs direct access to `/dev/input` devices to read evdev events for touchpad gesture detection on ASUS laptops. There is no portal or alternative Flatpak API available for low-level input event access.

  **`finish-args-kwin-talk-name`**
  The app communicates with KWin via D-Bus to query the active window state and integrate with the KDE Plasma window manager. This is required for proper desktop integration on KDE.

  **`finish-args-plasmashell-talk-name`**
The app uses the Plasma Shell D-Bus interface to display notifications and interact with the KDE desktop environment.

  **`finish-args-own-name-org.kde.StatusNotifierItem-2-1`** The app registers a system tray icon using the StatusNotifierItem protocol, which requires owning this specific well-known D-Bus name.

  **`finish-args-flatpak-spawn-access`**
The app uses `flatpak-spawn --host` to apply hardware settings by communicating with `asusd` and `supergfxctl` on the host system. These are privileged hardware daemons that run outside the sandbox and cannot be accessed via portals
