### PR TITLE
Update org.mozilla.thunderbird_esr exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7922,7 +7922,7 @@
     "org.mozilla.thunderbird_esr": {
         "stable": {
             "finish-args-gnupg-filesystem-access": "Use GnuPG for email encryption",
-            "finish-args-own-name-org.mozilla.thunderbird": "Thunderbird ESR uses the same dbus name as monthly release"
+            "finish-args-own-name-wildcard-org.mozilla.thunderbird": "Thunderbird ESR uses the same dbus name as monthly release"
         }
     },
     "org.musescore.MuseScore": {


### PR DESCRIPTION
We need to use the own name wildcard to handle our DBus use