### PR TITLE
Add org.projecttick.MeshMC wayland + x11 exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8117,7 +8117,7 @@
     },
     "org.projecttick.MeshMC": {
         "*": {
-            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+            "finish-args-contains-both-x11-and-wayland": "Minecraft currently needs X11/Xwayland compatibility on some systems. Without X11 access, the launched game process can fail during GLFW initialization with X11: The DISPLAY environment variable is missing, while Wayland support is still needed for the Qt launcher environment."
         }
     },
     "org.purei.Play": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8115,6 +8115,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "org.projecttick.MeshMC": {
+        "*": {
+            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+        }
+    },
     "org.purei.Play": {
         "stable": {
             "finish-args-home-ro-filesystem-access": "Predates the linter rule",


### PR DESCRIPTION
With wayland + fallback-x11 socket not defined DISPLAY variable and this one errors minecraft

~/org.projecttick.MeshMC fix-no-launch-minecraft
❯ flatpak install org.projecttick.MeshMC
Looking for matches…
Remotes found with refs similar to ‘org.projecttick.MeshMC’:

   1) ‘flathub’ (system)
   2) ‘flathub’ (user)

Which do you want to use (0 to abort)? [0-2]: 1

org.projecttick.MeshMC permissions:
    ipc                   network               fallback-x11       pulseaudio       wayland      x11      devices
    file access [1]       dbus access [2]

    [1] /sys/kernel/mm/hugepages:ro, /sys/kernel/mm/transparent_hugepage:ro, xdg-config/kdeglobals:ro, xdg-download:ro,
        xdg-run/app/com.discordapp.Discord:create, ~/.ftba:ro
    [2] com.canonical.AppMenu.Registrar, org.kde.KGlobalSettings, org.kde.kconfig.notify


        ID                              Branch          Op          Remote          Download
 1. [✓] org.projecttick.MeshMC          stable          i           flathub         381,0 MB / 382,5 MB

Installation complete.

~/org.projecttick.MeshMC fix-no-launch-minecraft 19s ❯ flatpak run --command=sh org.projecttick.MeshMC
[📦 org.projecttick.MeshMC ~]$ echo $DISPLAY

[📦 org.projecttick.MeshMC ~]$ exit
exit

~/org.projecttick.MeshMC fix-no-launch-minecraft 6s ❯ 

Minecraft error

https://pastee.dev/p/rrJG1Dd5

I uninstalled MeshMC Stable and install fixed one;

~/org.projecttick.MeshMC fix-no-launch-minecraft 51s ❯ flatpak uninstall org.projecttick.MeshMC


        ID                            Branch        Op
 1. [-] org.projecttick.MeshMC        stable        r

Uninstall complete.


I added this PR patch https://github.com/flathub/org.projecttick.MeshMC/pull/1

~/org.projecttick.MeshMC fix-no-launch-minecraft
❯ flatpak-builder --repo repo --jobs 6 --install --install-deps-from=flathub --user --sandbox --force-clean build-dir org.projecttick.MeshMC.yml Dependency Sdk: org.kde.Sdk 6.10
Updating org.kde.Sdk/x86_64/6.10

Nothing to do.
Dependency Runtime: org.kde.Platform 6.10
Updating org.kde.Platform/x86_64/6.10

Nothing to do.
Dependency Extension: org.freedesktop.Sdk.Extension.openjdk17 25.08 Updating org.freedesktop.Sdk.Extension.openjdk17/x86_64/25.08

Nothing to do.
Emptying app dir 'build-dir'
Downloading sources
Fetching git repo https://github.com/festvox/flite.git, ref refs/tags/v2.2 remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0) git: 'lfs' is not a git command. See 'git --help'.

The most similar command is
        refs
Fetching git repo https://github.com/glfw/glfw.git, ref refs/tags/3.4 remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 1 (delta 0), pack-reused 0 (from 0) Receiving objects: 100% (1/1), 172 bytes | 172.00 KiB/s, done. Starting build of org.projecttick.MeshMC
Cache hit for flite, skipping build
Cache hit for glfw, skipping build
Cache hit for xrandr, skipping build
Cache hit for glu, skipping build
Cache hit for glxinfo, skipping build
Cache hit for tomlplusplus, skipping build
Cache hit for meshmc, skipping build
Cache hit for cleanup, skipping
Cache hit for finish, skipping
Everything cached, checking out from cache
Exporting org.projecttick.MeshMC to repo
Commit: 5ea669312ea1a7ae5569110bdc852c637ad33f10afff7a0171aff9217f8a97d4 Metadata Total: 125
Metadata Written: 1
Content Total: 276
Content Written: 0
Content Bytes Written: 0 (0 bytes)
Exporting org.projecttick.MeshMC.Debug to repo
Commit: 1cbcff838d5af68388476c0b0d92163cf65e649598948efbec7b4aade87252ca Metadata Total: 485
Metadata Written: 1
Content Total: 1617
Content Written: 0
Content Bytes Written: 0 (0 bytes)
Installing app/org.projecttick.MeshMC/x86_64/master Installing runtime/org.projecttick.MeshMC.Debug/x86_64/master Pruning cache

~/org.projecttick.MeshMC fix-no-launch-minecraft 20s ❯ flatpak run --command=sh org.projecttick.MeshMC
[📦 org.projecttick.MeshMC ~]$ echo $DISPLAY
:0
[📦 org.projecttick.MeshMC ~]$ exit
exit

~/org.projecttick.MeshMC fix-no-launch-minecraft 16s ❯ 

Minecraft logs;

https://pastee.dev/p/52kiEzA0

But, i need wayland for MeshMC launcher performance and x11 needs launching Minecraft. Thanks.