### PR TITLE
Add exception for io.github.swordpuffin.rewaita

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4696,7 +4696,8 @@
     },
     "io.github.swordpuffin.rewaita": {
         "stable": {
-            "finish-args-autostart-filesystem-access": "Needed for manually creating an autostart file with specific parameters which cannot be done through Libportal"
+            "finish-args-autostart-filesystem-access": "Needed for manually creating an autostart file with specific parameters which cannot be done through Libportal",
+            "finish-args-flatpak-appdata-folder-access": "Needs to generate a Firefox css theme for any package format of Firefox, including Flatpak. The theme must be placed in Firefox's appdata directory"
         }
     },
     "io.github.swordpuffin.wardrobe": {


### PR DESCRIPTION
Rewaita generates a Firefox CSS theme if the user would like. I need this to work with every format of Firefox, including Flatpak, and the themes would need to be placed in Firefox's appdata directory. 

You can take a look at the [manifest](https://github.com/SwordPuffin/Rewaita/blob/main/io.github.swordpuffin.rewaita.json) to see what I mean. I just took a lot of this stuff from the old Gradience project although I've changed the implementation a bit for Rewaita's needs.

If you need to see the implementation, you can find it [here](https://github.com/SwordPuffin/Rewaita/blob/3a9e3b9b3bf711f27e862996a08f8bbcb98f5f70/src/themes/firefox_gnome_theme.py#L767).

Thanks,
NP.