### PR TITLE
Remove flatpak-spawn-access permission for de.schmidhuberj.tubefeeder

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2925,7 +2925,6 @@
     },
     "de.schmidhuberj.tubefeeder": {
         "*": {
-            "finish-args-flatpak-spawn-access": "Spawn arbitrary video player",
             "finish-args-unnecessary-xdg-data-tubefeeder-create-access": "the app predates this linter rule"
         }
     },


### PR DESCRIPTION
See the explanation in the [4.0.0 release MR](https://github.com/flathub/de.schmidhuberj.tubefeeder/pull/94) for reasoning.