### PR TITLE
Add exceptions for dev.qwery.AddWater

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3108,7 +3108,9 @@
     },
     "dev.qwery.AddWater": {
         "*": {
-            "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
+            "finish-args-flatpak-appdata-folder-access": "Needed to install theme to Flatpak'ed Firefox",
+            "finish-args-unnecessary-xdg-config-mozilla-rw-access": "Needed to install theme to Firefox profiles stored in xdg-config",
+            "finish-args-unnecessary-xdg-config-librewolf-rw-access": "Needed to install theme to Librewolf profiles stored in xdg-config"
         }
     },
     "dev.restfox.Restfox": {


### PR DESCRIPTION
Allow access to certain xdg-config subdirs to access Firefox profiles