### PR TITLE
io.github.moonlight_mod.moonlight-installer: add new discord installation paths

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4288,6 +4288,10 @@
             "finish-args-unnecessary-xdg-data-DiscordCanary-rw-access": "Needed to patch Discord Canary",
             "finish-args-unnecessary-xdg-data-DiscordDevelopment-rw-access": "Needed to patch Discord Development",
             "finish-args-unnecessary-xdg-data-DiscordPTB-rw-access": "Needed to patch Discord PTB",
+            "finish-args-unnecessary-xdg-config-discord-rw-access": "Needed to patch Discord",
+            "finish-args-unnecessary-xdg-config-discordcanary-rw-access": "Needed to patch Discord Canary",
+            "finish-args-unnecessary-xdg-config-discorddevelopment-rw-access": "Needed to patch Discord Development",
+            "finish-args-unnecessary-xdg-config-discordptb-rw-access": "Needed to patch Discord PTB",
             "finish-args-unnecessary-xdg-data-flatpak-create-access": "Needed to set permission overrides",
             "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needed to patch Flatpak installations of Discord"
         }


### PR DESCRIPTION
discord recently turned the main app directory into a shim that downloads and calls ~/.config/(installation)/app-(version)/(binary), so we will need to include those new paths