### PR TITLE
Add exception for io.github.avomar.dev-toolbox

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3715,6 +3715,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.avomar.dev-toolbox": {
+        "stable": {
+            "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"
+        }
+    },
     "io.github.bcpierce00.unison": {
         "stable": {
             "finish-args-flatpak-appdata-folder-access": "Unison must be able to sync all the user's data or config files",


### PR DESCRIPTION
### Summary

Add linter exception for Dev Toolbox app:

    finish-args-unnecessary-xdg-config-cosmic-ro-access: Required to read the system theme and listen for changes to config