### PR TITLE
Add exception for me.spaceinbox.swiftynotes

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5262,6 +5262,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "me.spaceinbox.swiftynotes": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Notes app stores each note as a plain markdown file; users select their notes library directory and commonly point it at cloud-synced folders (Syncthing, Nextcloud, Dropbox, custom rclone mounts) outside standard XDG locations so notes stay in sync across devices"
+        }
+    },
     "me.timschneeberger.GalaxyBudsClient": {
         "stable": {
             "finish-args-own-name-wildcard-org.kde": "The used version of the toolkit Avalonia only supports legacy KDE system tray icons: https://github.com/AvaloniaUI/Avalonia/issues/13782"


### PR DESCRIPTION
## Why this exception is needed

[Swifty Notes](https://github.com/makoni/swifty-notes-gtk) is a markdown notes application that stores each note as a plain `.md` file on disk. A core feature is letting users pick the directory where their notes library lives, and the most common use case is pointing it at a cloud-synced folder so notes stay in sync across devices and machines.

In practice users select directories like:

- `~/Syncthing/Notes`
- `~/Nextcloud/Notes`
- `~/Dropbox/Notes`
- `~/<arbitrary>/<rclone-mount>/Notes`

These do not live under `~/Documents` or any other XDG-standard location, so `--filesystem=xdg-documents` (or any combination of XDG aliases) does not cover the use case. Without `--filesystem=home` the user sees a synthetic `/run/user/UID/doc/HASH/<basename>/` portal bind-mount path in Settings — that path is non-persistent across sessions and breaks the relocator's move/rename workflow when transitioning between portal-mount paths and sandbox storage. This is being tracked upstream as makoni/swifty-notes-gtk#13.

This is the same access pattern other notes / editor apps on Flathub already use: Joplin, Standard Notes, Logseq, gedit, kate.

The Flathub manifest PR that adopts this is https://github.com/flathub/me.spaceinbox.swiftynotes/pull/7.

Linter error this exception resolves:

```
'finish-args-home-filesystem-access' error found in linter manifest check.
```