### PR TITLE
Adding exception for gov.nasa.giss.Panoply

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9003,5 +9003,10 @@
         "stable": {
             "finish-args-home-filesystem-access": "Requred for importing and exporting files from the app due to it lacking xdg portals support."
         }
+    },
+    "gov.nasa.giss.Panoply": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Required for importing and exporting files from the app due to it lacking xdg portals support."
+        }
     }
 }


### PR DESCRIPTION
Required for https://github.com/flathub/flathub/pull/8499. 

<img width="500" height="361" alt="grafik" src="https://github.com/user-attachments/assets/09df6d5e-50e4-435a-8896-cdff09d1916e" />

The application uses Java Swing, which starts in `$HOME` and will otherwise be broken.