### PR TITLE
Add exception for com.clustta.clustta

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -491,6 +491,11 @@
             "finish-args-unnecessary-xdg-data-Trash-rw-access": "Needs direct trash access, doesn't use portal"
         }
     },
+    "com.clustta.clustta": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Version control tool requiring direct access to user-chosen project directories"
+        }
+    },
     "com.carpeludum.KegaFusion": {
         "stable": {
             "finish-args-home-ro-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Clustta is a version control and collaboration tool that manages user-chosen project directories at arbitrary locations under $HOME. Persistent read/write access is required for file watching (fsnotify), checkpoint creation, and sync operations.