### PR TITLE
Requesting exceptions for io.github.arijanj.Mimic

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3720,6 +3720,16 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.arijanj.Mimic": {
+        "stable": {
+            "finish-args-host-os-ro-filesystem-access": "Needs access to /usr/share/applications to view applications, /usr/share/icons and /usr/share/pixmaps to render icons",
+            "finish-args-arbitrary-xdg-config-create-access": "Writing mimeapps.list if it doesn't exist",
+            "finish-args-desktopfile-filesystem-access": "For listing applications installed in ~/.local/share/applications",
+            "finish-args-flatpak-system-folder-access": "For listing Flatpak applications",
+            "finish-args-flatpak-user-folder-access": "For listing user Flatpak application",
+            "finish-args-host-var-access": "For listing Flatpak and snapd applications"
+        }
+    },
     "io.github.avomar.dev-toolbox": {
         "stable": {
             "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3723,11 +3723,14 @@
     "io.github.arijanj.Mimic": {
         "stable": {
             "finish-args-host-os-ro-filesystem-access": "Needs access to /usr/share/applications to view applications, /usr/share/icons and /usr/share/pixmaps to render icons",
+            "finish-args-host-var-access": "For listing Flatpak and snapd applications",
             "finish-args-arbitrary-xdg-config-create-access": "Writing mimeapps.list if it doesn't exist",
             "finish-args-desktopfile-filesystem-access": "For listing applications installed in ~/.local/share/applications",
-            "finish-args-flatpak-system-folder-access": "For listing Flatpak applications",
-            "finish-args-flatpak-user-folder-access": "For listing user Flatpak application",
-            "finish-args-host-var-access": "For listing Flatpak and snapd applications"
+            "finish-args-flatpak-system-folder-exports-share-applications-ro-access": "For listing Flatpak apps",
+            "finish-args-flatpak-system-folder-exports-share-icons-ro-access": "For accessing Flatpak app icons (symlink directory)"
+            "finish-args-flatpak-system-folder-app-ro-access": "For accessing Flatpak app icons (symlink targets)",
+            "finish-args-flatpak-user-folder-exports-share-applications-ro-access": "For listing user-installed Flatpak apps",
+            "finish-args-flatpak-user-folder-exports-share-icons-ro-access": "For accessing user-installed Flatpak app icons"
         }
     },
     "io.github.avomar.dev-toolbox": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3727,7 +3727,7 @@
             "finish-args-arbitrary-xdg-config-create-access": "Writing mimeapps.list if it doesn't exist",
             "finish-args-desktopfile-filesystem-access": "For listing applications installed in ~/.local/share/applications",
             "finish-args-flatpak-system-folder-exports-share-applications:ro-access": "For listing Flatpak apps",
-            "finish-args-flatpak-system-folder-exports-share-icons:ro-access": "For accessing Flatpak app icons (symlink directory)"
+            "finish-args-flatpak-system-folder-exports-share-icons:ro-access": "For accessing Flatpak app icons (symlink directory)",
             "finish-args-flatpak-system-folder-app:ro-access": "For accessing Flatpak app icons (symlink targets)",
             "finish-args-flatpak-user-folder-exports-share-applications:ro-access": "For listing user-installed Flatpak apps",
             "finish-args-flatpak-user-folder-exports-share-icons:ro-access": "For accessing user-installed Flatpak app icons"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3726,11 +3726,11 @@
             "finish-args-host-var-access": "For listing Flatpak and snapd applications",
             "finish-args-arbitrary-xdg-config-create-access": "Writing mimeapps.list if it doesn't exist",
             "finish-args-desktopfile-filesystem-access": "For listing applications installed in ~/.local/share/applications",
-            "finish-args-flatpak-system-folder-exports-share-applications-ro-access": "For listing Flatpak apps",
-            "finish-args-flatpak-system-folder-exports-share-icons-ro-access": "For accessing Flatpak app icons (symlink directory)"
-            "finish-args-flatpak-system-folder-app-ro-access": "For accessing Flatpak app icons (symlink targets)",
-            "finish-args-flatpak-user-folder-exports-share-applications-ro-access": "For listing user-installed Flatpak apps",
-            "finish-args-flatpak-user-folder-exports-share-icons-ro-access": "For accessing user-installed Flatpak app icons"
+            "finish-args-flatpak-system-folder-exports-share-applications:ro-access": "For listing Flatpak apps",
+            "finish-args-flatpak-system-folder-exports-share-icons:ro-access": "For accessing Flatpak app icons (symlink directory)"
+            "finish-args-flatpak-system-folder-app:ro-access": "For accessing Flatpak app icons (symlink targets)",
+            "finish-args-flatpak-user-folder-exports-share-applications:ro-access": "For listing user-installed Flatpak apps",
+            "finish-args-flatpak-user-folder-exports-share-icons:ro-access": "For accessing user-installed Flatpak app icons"
         }
     },
     "io.github.avomar.dev-toolbox": {


### PR DESCRIPTION
Hello, Mimic is an application that lets users graphically set their default applications (mimeapps.list) regardless of which DE/WM they're using; even if their DE has a 'default applications' menu, Mimic gives much more granular control. (https://github.com/flathub/flathub/pull/8543)

For that purpose, it needs to iterate through all .desktop files on the system. I've added the most common locations, and this works fine on a bunch of different distributions I've tried. From all the research I've done, these should be the minimum permissions possible to put the app in a working state.

I understand this is a bit of a dubious use-case, but I think having something this available on Flathub would be very useful, as I use the somewhat similar https://flathub.org/en/apps/io.github.fabrialberio.pinapp app on all my devices.