### PR TITLE
Add exception for com.ledger.wallet

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9018,5 +9018,10 @@
         "stable": {
             "finish-args-home-filesystem-access": "Required for importing and exporting files from the app due to it lacking xdg portals support."
         }
+    },
+    "com.ledger.wallet": {
+        "stable": {
+            "finish-args-only-wayland": "This program doesn't support x11."
+        }
     }
 }


### PR DESCRIPTION
This program doesn't support x11.

```
Ledger Wallet 4.0.0
T-electron: 266ms
T-imports: 203.89ms
[2:0503/205636.605683:ERROR:ui/ozone/platform/wayland/host/wayland_connection.cc:202] Failed to connect to Wayland display: No such file or directory (2)
[2:0503/205636.605780:ERROR:ui/ozone/platform/wayland/ozone_platform_wayland.cc:282] Failed to initialize Wayland platform
[2:0503/205636.605800:ERROR:ui/aura/env.cc:257] The platform failed to initialize.  Exiting.
```

^ Running under x11.

Adding this for: https://github.com/flathub/flathub/pull/8547