### PR TITLE
exceptions: add finish-args-flatpak-spawn-access for io.github.totoshko88.RustConn

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4762,7 +4762,9 @@
     "io.github.totoshko88.RustConn": {
         "stable": {
             "finish-args-has-socket-ssh-auth": "Needed for SSH agent authentication",
-            "finish-args-ssh-filesystem-access": "Needed to manage SSH keys and configurations for connections"
+            "finish-args-ssh-filesystem-access": "Needed to manage SSH keys and configurations for connections",
+            "finish-args-flatpak-spawn-access": "Needed to launch host binaries (ssh, xfreerdp, vncviewer, remote-viewer, picocom) via flatpak-spawn --host since they are unavailable inside the sandbox"
+
         }
     },
     "io.github.trevorsandy.LPub3D": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4763,8 +4763,7 @@
         "stable": {
             "finish-args-has-socket-ssh-auth": "Needed for SSH agent authentication",
             "finish-args-ssh-filesystem-access": "Needed to manage SSH keys and configurations for connections",
-            "finish-args-flatpak-spawn-access": "Needed to launch host binaries (ssh, xfreerdp, vncviewer, remote-viewer, picocom) via flatpak-spawn --host since they are unavailable inside the sandbox"
-
+            "finish-args-flatpak-spawn-access": "Local Shell feature opens an interactive host shell session via flatpak-spawn --host for user-initiated terminal access"
         }
     },
     "io.github.trevorsandy.LPub3D": {


### PR DESCRIPTION
Added new finish-args for SSH and flatpak-spawn access.

The existing exceptions (finish-args-has-socket-ssh-auth, finish-args-ssh-filesystem-access) were granted in the initial Flathub submission. The --talk-name=org.freedesktop.Flatpak finish-arg has been present in the manifest since the first release but the corresponding linter exception was not requested at that time.

Users requests for the full Local Shell experience

https://github.com/totoshko88/RustConn/issues/122