### PR TITLE
Add appid-url-not-reachable exception for com.chirpmyradio.chirp

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9011,7 +9011,8 @@
     },
     "com.chirpmyradio.chirp": {
         "stable": {
-            "finish-args-home-filesystem-access": "Requred for importing and exporting files from the app due to it lacking xdg portals support."
+            "finish-args-home-filesystem-access": "Required for importing and exporting files from the app due to it lacking xdg portals support.",
+            "appid-url-not-reachable": "Required due to project website blocking bots using Cloudflare"
         }
     },
     "gov.nasa.giss.Panoply": {


### PR DESCRIPTION
The project website blocks the linter using Cloudflare.

Recommendation: https://github.com/flathub/flathub/pull/8379#issuecomment-4365983583
Build log: https://github.com/flathub-infra/vorarbeiter/actions/runs/25276972733