### PR TITLE
exceptions: add dev.lonecloud.gerbil

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3006,6 +3006,12 @@
             "finish-args-host-filesystem-access": "Predates the linter rule"
         }
     },
+    "dev.lonecloud.gerbil": {
+        "stable": {
+            "finish-args-host-filesystem-access": "required to access LLM model files and the KoboldCpp binary, which users may store anywhere on their filesystem",
+            "finish-args-flatpak-spawn-access": "required to run host monitoring commands (nvidia-smi, rocm-smi, top) to display real-time GPU/CPU metrics during inference"
+        }
+    },
     "dev.geopjr.Turntable": {
         "stable": {
             "finish-args-flatpak-appdata-folder-access": "Required to read the local MPRIS artUrl files from flatpak MPRIS clients",


### PR DESCRIPTION
Flathub PR: flathub/flathub#8568

`finish-args-host-filesystem-access`: required to access LLM model files and the KoboldCpp binary, which users may store anywhere on their filesystem

`finish-args-flatpak-spawn-access`: required to launch host system monitor applications (top, htop, gnome-system-monitor, plasma-systemmonitor, etc.) from the tray when requested by the user