### PR TITLE
finish-args: Drop device=input and usb lints

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -143,20 +143,6 @@ class FinishArgsCheck(Check):
                         "finish-args-insufficient-required-flatpak: finish-args has"
                         + " 'input' or 'usb' device but 'require-version' is not >=1.16.0"
                     )
-                if dev == "input":
-                    self.errors.add("finish-args-has-dev-input")
-                    self.info.add(
-                        "finish-args-has-dev-input: This permissions is not backwards"
-                        + " compatible with a supported Flatpak release 1.14.x and"
-                        + " requires an exception"
-                    )
-                if dev == "usb":
-                    self.errors.add("finish-args-has-dev-usb")
-                    self.info.add(
-                        "finish-args-has-dev-input: This permissions is not backwards"
-                        + " compatible with a supported Flatpak release 1.14.x and"
-                        + " requires an exception"
-                    )
 
         modes = (":ro", ":rw", ":create")
         xdgdirs = ("xdg-data", "xdg-config", "xdg-cache")

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -321,7 +321,6 @@ def test_manifest_finish_args_new_metadata() -> None:
     found_errors = set(ret["errors"])
     errors = {
         "finish-args-insufficient-required-flatpak",
-        "finish-args-has-dev-input",
     }
     for err in errors:
         assert err in found_errors


### PR DESCRIPTION
Enough time has passed since 1.16.0 and a new LTS release of Ubuntu and soon a new stable release of Flatpak will be available. 1.14.x which didn't had this is unsupported entirely, so let's allow these.

After this, `--device=input, usb` can be used as long as `--require-version=X` (X >=1.16.0) is used. The lint still requiring a `--require-version=X is kept as is.