### PR TITLE
Add exception for io.github.kyuyrii.meganimus

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4903,6 +4903,12 @@
             "finish-args-host-tmp-access": "Predates the linter rule"
         }
     },
+    "io.github.kyuyrii.meganimus": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Required for .desktop files to use the actual file path selected by the user.",
+            "finish-args-flatpak-appdata-folder-access": "Required for .desktop files to use the actual file path selected by the user."
+        }
+    },
     "io.github.kyuyrii.zordeer": {
         "stable": {
             "finish-args-home-filesystem-access": "The UMU launcher needs direct access to function. Using the Document Portal prevents it from working."


### PR DESCRIPTION
The reason you need "finish-args-home-filesystem-access" and "finish-args-flatpak-appdata-folder-access" is that without this access, when selecting a file, the path obtained is not the actual path of the native game, .exe file, or ROM, and the Document Portal isolates the selected file.

So if the user selects something with the Document Portal, the .desktop file created by Meganimus will break.

If it's a native game, the file that runs the game will not find the game files.

If it's an .exe file, for example, if it's to be run with the Flatpak version of Wine (org.winehq.Wine), using a Document Portal path will prevent Wine from executing the .exe file. This is because even if it's inside the `$HOME/.var/app/org.winehq.Wine` folder, Wine won't be able to access that path created by the Document Portal. Even if it could, the .exe file would be isolated, causing the same problem that occurs with native games.

https://github.com/user-attachments/assets/ddbeef22-a445-480d-8a90-66b85f26d22e