### PR TITLE
Add pylux exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3523,6 +3523,11 @@
             "finish-args-flatpak-appdata-folder-access": "Predates the linter rule"
         }
     },
+    "io.github.ForWard_Technologies_LLC.Pylux": {
+        "new-pr": {
+            "finish-args-login1-system-talk-name": "Required to receive the PrepareForSleep signal from logind so active streaming sessions can be cleanly torn down before the system suspends. Idle inhibit is handled via org.freedesktop.portal.Inhibit which needs no manifest permission; login1 is used solely for the PrepareForSleep signal which has no portal equivalent."
+        }
+    },
     "io.github.ImEditor": {
         "*": {
             "appid-code-hosting-too-few-components": "app-id predates this linter rule"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3524,7 +3524,7 @@
         }
     },
     "io.github.ForWard_Technologies_LLC.Pylux": {
-        "*": {
+        "stable": {
             "finish-args-login1-system-talk-name": "Needed for the PrepareForSleep signal from logind to cleanly tear down active streaming sessions on suspend. No portal equivalent exists for this signal."
         }
     },

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3524,8 +3524,8 @@
         }
     },
     "io.github.ForWard_Technologies_LLC.Pylux": {
-        "new-pr": {
-            "finish-args-login1-system-talk-name": "Required to receive the PrepareForSleep signal from logind so active streaming sessions can be cleanly torn down before the system suspends. Idle inhibit is handled via org.freedesktop.portal.Inhibit which needs no manifest permission; login1 is used solely for the PrepareForSleep signal which has no portal equivalent."
+        "*": {
+            "finish-args-login1-system-talk-name": "Needed for the PrepareForSleep signal from logind to cleanly tear down active streaming sessions on suspend. No portal equivalent exists for this signal."
         }
     },
     "io.github.ImEditor": {


### PR DESCRIPTION
Add linter exception for `io.github.ForWard_Technologies_LLC.Pylux` (Flathub submission: flathub/flathub#8607).

**`finish-args-login1-system-talk-name`**: Required to receive the `PrepareForSleep` signal from logind so active streaming sessions can be cleanly torn down before the system suspends. Idle inhibit is already handled via `org.freedesktop.portal.Inhibit` (no manifest permission needed); `login1` is used solely for the `PrepareForSleep` signal, which has no portal equivalent. This is especially relevant on Steam Deck where suspend is the primary way to end a session.