### PR TITLE
Add exception for org.nuicpp.nui_sftp

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9117,5 +9117,11 @@
         "stable": {
             "finish-args-home-filesystem-access": "Required for importing and exporting files from the app due to it lacking xdg portals support."
         }
+    },
+    "org.nuicpp.nui_sftp": {
+        "stable": {
+            "finish-args-host-filesystem-access": "SFTP client needs direct access to user-chosen local paths outside home (removable media, /mnt, /srv, project trees) for transfer, sync, and directory-watch operations. FileChooser portal is used where the user picks individual files, but background transfers and watched directories need persistent access to the chosen paths.",
+            "finish-args-has-socket-ssh-auth": "Required to use the user's running SSH agent for public-key authentication against remote hosts (the standard mechanism for yubikey/gpg-agent/passphrase-protected keys)."
+        }
     }
 }


### PR DESCRIPTION
Adds linter exceptions for `org.nuicpp.nui_sftp` (an SFTP client).

App: https://github.com/flathub/org.nuicpp.nui_sftp
Upstream: https://github.com/5cript/nui-sftp

### `finish-args-host-filesystem-access`

nui-sftp is an interactive SFTP client. Users routinely sync, watch, and transfer files between arbitrary local directories and remote hosts, including removable media (`/run/media`), system mounts (`/mnt`, `/media`), shared service directories (`/srv`), and project trees outside their home directory. Limiting the sandbox to `--filesystem=home` would silently break these flows for users who reasonably expect a file-transfer tool to reach the locations their shell can reach.

The application uses the FileChooser portal where the user picks individual files, but the underlying transfer operations and the directory-watch / auto-reupload feature need persistent filesystem access to the chosen paths, which the portal does not provide.

### `finish-args-has-socket-ssh-auth`

`ssh-auth` is required so the application can use the user's running SSH agent for public-key authentication. Forwarding the agent is the standard way an SSH/SFTP client authenticates against remote hosts whose private keys are held in the agent.