### PR TITLE
best.ellie.StartupConfiguration: add new fs exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -144,7 +144,8 @@
             "finish-args-flatpak-user-folder-app-ro-access": "This app requires read-only access to the hosts' ~/.local/share/flatpak/exports/share/{applications,icons} directories in order to allow users to add them to the applications launched on startup.",
             "finish-args-host-ro-filesystem-access": "Predates the linter rule",
             "finish-args-host-var-access": "This app requires read-only access to the hosts' /var/lib/snapd/desktop/applications directory in order to allow users to add snaps to the applications launched on startup.",
-            "finish-args-unnecessary-xdg-config-autostart-create-access": "This app requires access to the hosts' ~/.config/autostart directory in create mode in order to manage applications launched on startup."
+            "finish-args-unnecessary-xdg-config-autostart-create-access": "This app requires access to the hosts' ~/.config/autostart directory in create mode in order to manage applications launched on startup.",
+            "finish-args-unnecessary-xdg-config-cosmic-ro-access": "This app requires read-only access to the hosts' ~/.config/cosmic directory in order to respect theming for COSMIC apps."
         }
     },
     "br.app.pw3270.terminal": {


### PR DESCRIPTION
hello!

when i submitted this app originally, i missed the filesystem permission for `xdg-config/cosmic:ro` which is needed to respect theming for COSMIC apps.

https://github.com/flathub/best.ellie.StartupConfiguration/pull/6 adds the permission in, but is blocked as an exception needs to be granted.