### PR TITLE
Add exceptions for io.github.ebkr.r2modman

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9127,8 +9127,9 @@
     },
     "io.github.ebkr.r2modman": {
         "*": {
-            "finish-args-flatpak-spawn-access": "Required to launch Steam games on the Steam Deck when in game mode",
-            "finish-args-host-filesystem-access": "Required to detect installed games and mod files across host and Steam library locations"
+            "finish-args-flatpak-spawn-access": "Required to launch Steam games on the Steam Deck in game mode",
+            "finish-args-host-filesystem-access": "Required to resolve Steam install locations and user installed games",
+            "finish-args-flatpak-appdata-folder-com.valvesoftware.Steam-rw-access": "Required to resolve the Steam install location from the Flatpak Steam directory (which isnt covered by host access)"
         }
     }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9124,5 +9124,11 @@
             "finish-args-host-filesystem-access": "SFTP client needs direct access to user-chosen local paths outside home (removable media, /mnt, /srv, project trees) for transfer, sync, and directory-watch operations. FileChooser portal is used where the user picks individual files, but background transfers and watched directories need persistent access to the chosen paths.",
             "finish-args-has-socket-ssh-auth": "Required to use the user's running SSH agent for public-key authentication against remote hosts (the standard mechanism for yubikey/gpg-agent/passphrase-protected keys)."
         }
+    },
+    "io.github.ebkr.r2modman": {
+        "*": {
+            "finish-args-flatpak-spawn-access": "Required to launch Steam games on the Steam Deck when in game mode",
+            "finish-args-host-filesystem-access": "Required to detect installed games and mod files across host and Steam library locations"
+        }
     }
 }


### PR DESCRIPTION
Add linter exceptions for `io.github.ebkr.r2modman` ([flathub submission](https://github.com/flathub/flathub/pull/8694))

- `finish-args-flatpak-spawn-access`: r2modman works by launching games through Steam while adding custom launch arguments, which means it needs to be able to launch Steam. On the steam deck, xdg portals dont work correctly, and the Steam protocol isn't registered, so we need to invoke the host Steam binary directly with `flatpak-spawn`.
- `finish-args-host-filesystem-access`: r2modman needs to be able to locate the files for games in order to mod them. Game files could be in any location on the device, so host file system access is needed to allow the app to function.