### PR TITLE
Add exception for gay.brie.CheesePaper

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3356,6 +3356,12 @@
             "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write to system configuration files"
         }
     },
+    "gay.brie.CheesePaper": {
+        "stable": {
+            "finish-args-unnecessary-xdg-config-cheese-paper-rw-access": "Users may need to access the settings directory (e.g., adding dictionaries)",
+            "finish-args-unnecessary-xdg-data-cheese-paper-rw-access": "Users may need to access the data directory (e.g., collecting logs, unignoring words"
+        }
+    },
     "gg.minion.Minion": {
         "*": {
             "finish-args-flatpak-appdata-folder-com.valvesoftware.Steam-rw-access": "Predates the linter rule"


### PR DESCRIPTION
Based on flathub/flathub#8714

While most of the typical user interaction will be done entirely via UI, there are a few cases where users will need to interface with files directly, including both the `xdg-config/cheese-paper` and `xdg-data/cheese-paper` directories. These instances should be fairly rare, but they do exist, and are documented in the manual (and, to a lesser extent, in the UI).