### PR TITLE
Add exception for net.huangyuhui.hmcl

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5495,6 +5495,12 @@
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
         }
     },
+    "net.huangyuhui.hmcl": {
+        "stable": {
+            "finish-args-contains-both-x11-and-wayland": "JavaFX application requires both X11 and Wayland sockets to function correctly",
+            "appid-url-not-reachable": "The correct url is hmcl.huangyuhui.net."
+        }
+    },
     "net.imaginaryinfinity.Squiid": {
         "stable": {
             "finish-args-not-defined": "Is a command line application"


### PR DESCRIPTION
1. the correct domain is hmcl.huangyuhui.net or www.huangyuhui.net. And i have already asked the upstream dev to fix certificate issue.

2. Because JavaFX only supports X11 but some Minecraft build supports Wayland. If I choose to use fallback-x11 and wayland, HMCL won't start.