### PR TITLE
Add exception for com.dekomote.vermouth

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -562,6 +562,11 @@
             "finish-args-kwin-talk-name": "Required to talk to a KWin script for getting the focused window name"
         }
     },
+    "com.dekomote.vermouth": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Required for umu and Proton to run the games, scan for runtimes and retroarch cores"
+        }
+    },
     "com.devolutions.remotedesktopmanager": {
         "stable": {
             "finish-args-has-socket-ssh-auth": "Predates the linter rule"


### PR DESCRIPTION
Per the discussion with the admin [here](https://github.com/flathub/flathub/pull/8702), i'm adding the exception for the finish-args-home-filesystem-access.

The reasoning is that most of the runtimes and games live inside the users home dir. Furthermore, portal won't work since portal either gives access to the whole folder or one file, and I need to have both, but choosing the game exe doesn't necessarily give me information of the true parent folder that Proton or game engine will need access for.