### PR TITLE
Add exception for net.windower.Lumoria

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5793,6 +5793,11 @@
             "flathub-json-automerge-enabled": "Predates the linter rule"
         }
     },
+    "net.windower.Lumoria": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Wine/Proton have issues running game under sandbox, occasionally settings get reset due to launcher bugs. SteamOS xdg-document-portal process takes up all CPU when installing and hangs device if outside of sandbox."
+        }
+    },
     "net.wz2100.wz2100": {
         "*": {
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
Adjusting permissions in Flathub Manifest to be more in line With [XIVLauncher](https://github.com/flathub/dev.goats.xivlauncher) and [Lutris](https://github.com/flathub/net.lutris.Lutris). After user testing, users are running into quite a few different issues with portals and Wine. Massive slowdowns due to overhead of the portal and more. Our users are moving from Lutris so these permissions will not come as a surprise.

In relation to: https://github.com/flathub/net.windower.Lumoria/pull/11