### PR TITLE
Add org.tahoma2d.Tahoma2D exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9112,5 +9112,10 @@
             "finish-args-host-filesystem-access": "SFTP client needs direct access to user-chosen local paths outside home (removable media, /mnt, /srv, project trees) for transfer, sync, and directory-watch operations. FileChooser portal is used where the user picks individual files, but background transfers and watched directories need persistent access to the chosen paths.",
             "finish-args-has-socket-ssh-auth": "Required to use the user's running SSH agent for public-key authentication against remote hosts (the standard mechanism for yubikey/gpg-agent/passphrase-protected keys)."
         }
+    },
+    "org.tahoma2d.Tahoma2D": {
+        "stable": {
+            "finish-args-host-filesystem-access": "Tahoma2D is regularly used in conjunction with other drawing or imagining applications and must be able to import and/or write image files whereever it needs to so it can be shared by other software involved in their animation pipeline."
+        }
     }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9115,7 +9115,7 @@
     },
     "org.tahoma2d.Tahoma2D": {
         "stable": {
-            "finish-args-host-filesystem-access": "Tahoma2D is regularly used in conjunction with other drawing or imagining applications and must be able to import and/or write image files whereever it needs to so it can be shared by other software involved in their animation pipeline."
+            "finish-args-host-filesystem-access": "Tahoma2D is regularly used in conjunction with other drawing or imagining applications and must be able to import and/or write image files whereever it needs to so it can be shared by other software involved in their animation pipeline. Additionally, some image and audio files require ffmpeg or rhubarb and users need to set the location of these executables in preferences for use by the application."
         }
     }
 }


### PR DESCRIPTION
Submitting this exception to be added for org.tahoma2d.Tahoma2D to go along with my Flatpak app submission (https://github.com/flathub/flathub/pull/8742).

Tahoma2D is an animation software that is used regularly with other drawing software in an animation pipeline and needs to be able to share image files between them which could be anywhere on their system.

Edi: Also, Tahoma2D needs to be able to configure the location and run external explications, ffmpeg and rhubarb to ingest certain image formats and audio tracks. 