### PR TITLE
Add OneKey flatpak-spawn exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8941,6 +8941,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "so.onekey.Wallet": {
+        "stable": {
+            "finish-args-flatpak-spawn-access": "Required to run pkexec on the host via flatpak-spawn to install OneKey udev rules for USB hardware wallet access"
+        }
+    },
     "space.fips.Fips": {
         "stable": {
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",


### PR DESCRIPTION
## Summary
- Add `finish-args-flatpak-spawn-access` exception for `so.onekey.Wallet` in the stable repo.
- OneKey uses this Flatpak permission for a narrow host authorization flow: `flatpak-spawn --host pkexec` installs the official OneKey udev rules needed for USB hardware wallet WebUSB access.

## Context
- Flathub manifest PR: https://github.com/flathub/so.onekey.Wallet/pull/84
- App-side implementation PR: https://github.com/OneKeyHQ/app-monorepo/pull/11626
- Without this exception, the Flathub manifest fails `validate-manifest` with `finish-args-flatpak-spawn-access`.

## Validation
- `python -m json.tool flatpak_builder_lint/staticfiles/exceptions.json >/dev/null`
- `python utils/validator.py flatpak_builder_lint/staticfiles/exceptions.json`