### PR TITLE
Add exception for ai.lemonade_server.Lemonade

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,9 @@
 {
+    "ai.lemonade_server.Lemonade": {
+        "stable": {
+            "finish-args-unnecessary-xdg-cache-huggingface-rw-access": "Lemonade is a local LLM server; this reuses the user's existing ~/.cache/huggingface so multi-gigabyte models already downloaded by other tools (huggingface_hub, transformers, llama.cpp) are not re-downloaded into the sandbox's private cache. Access is scoped to the huggingface subdirectory."
+        }
+    },
     "ai.opencode.opencode": {
         "*": {
             "finish-args-home-filesystem-access": "Needed to access and modify projects outside the sandbox"


### PR DESCRIPTION
Requesting a lint exception for `finish-args-unnecessary-xdg-cache-huggingface-rw-access`.

**App:** `ai.lemonade_server.Lemonade` . Lemonade, is a local LLM server + desktop app.
**Flathub submission:** https://github.com/flathub/flathub/pull/8748

**Why:** The app reuses and manages the user's existing `~/.cache/huggingface` so multi-gigabyte models already downloaded by other host tools (huggingface_hub, transformers, llama.cpp) aren't re-downloaded into the sandbox's private cache. Access is scoped to the `huggingface` subdirectory (not all of `xdg-cache`).

