### PR TITLE
Add exception for com.devolutions.remotedesktopmanager

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -569,7 +569,8 @@
     },
     "com.devolutions.remotedesktopmanager": {
         "stable": {
-            "finish-args-has-socket-ssh-auth": "Predates the linter rule"
+            "finish-args-has-socket-ssh-auth": "Predates the linter rule",
+            "finish-args-flatpak-spawn-access": "Required for Local Terminal and PowerShell to spawn host shells."
         }
     },
     "com.diffingo.fwbackups": {


### PR DESCRIPTION
App: https://github.com/flathub/com.devolutions.remotedesktopmanager
Upstream: https://devolutions.net/remote-desktop-manager/
Manifest PR: https://github.com/flathub/com.devolutions.remotedesktopmanager/pull/32


**finish-args-flatpak-spawn-access** is needed for two features in RDM:

1. For the Local Terminal. We have a builtin terminal feature. The shell is user configurable in the preferences. The point of this feature is to give the user their host shell with their PATH, ssh-agent and host tools. A sandboxed shell cant see these.

2. For PowerShell connection type in external mode: the pwsh session run inside the user's host terminal emulator (gnome-terminal, konsole, xterm, and more). The user picks which one in the preferences.. flatpak-spawn launches it, the emulator runs pwsh. It cant be sandboxed because the point of pwsh on Linux for our users is to access to host tools.