### PR TITLE
Update exception for org.zdoom.UZDoom

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8654,7 +8654,7 @@
     },
     "org.zdoom.UZDoom": {
         "beta": {
-            "finish-args-flatpak-appdata-folder-access": "UZDoom can automatically detect required data for supported games from Steam installations"
+            "finish-args-flatpak-appdata-folder-com.valvesoftware.Steam-data-Steam-steamapps-ro-access": "UZDoom can automatically detect required data for supported games from Steam installations"
         }
     },
     "org.zim_wiki.Zim": {


### PR DESCRIPTION
App: https://github.com/flathub/org.zdoom.UZDoom
Upstream: https://github.com/UZDoom/UZDoom

The rule already existed, but is failing now due to a change in how granular it is