### PR TITLE
Add exception for io.github.voltkraft.immich-folder-watch

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4889,6 +4889,11 @@
             "finish-args-legacy-icon-folder-permission": "Specifically meant to save desktop settings"
         }
     },
+    "io.github.voltkraft.immich-folder-watch": {
+      "*": {
+          "finish-args-own-name-wildcard-org.kde": "StatusNotifierItem tray integration for Avalonia."
+      }
+   },
     "io.github.voxelcubes.deepqt": {
         "stable": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Avalonia's StatusNotifierItem tray integration owns a runtime-generated org.kde.StatusNotifierItem-<pid>-<id> bus name. The Flatpak D-Bus proxy only supports subtree wildcards, so org.kde.* is the narrowest pattern that matches the generated SNI name.