### PR TITLE
Add exception for org.koderoots.chatqt

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7828,6 +7828,11 @@
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
         }
     },
+    "org.koderoots.chatqt": {
+        "stable": {
+            "finish-args-flatpak-spawn-access": "Requires use of OpenCode and Pi agent access on the host"
+        }
+    },
     "org.ksnip.ksnip": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule",


### PR DESCRIPTION
In ChatQT, we have some experimental features like using local MCPs, OpenCode and Pi inside the app. We need to use flatpak spawn for that.

Related PR: https://github.com/flathub/flathub/pull/8764

https://github.com/user-attachments/assets/67942cc3-ad90-48bd-9db9-9f078a10c317