### PR TITLE
Add exception for org.praat.Praat

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8180,7 +8180,7 @@
         "stable": {
             "finish-args-home-filesystem-access": "Scripts need to be able to access arbitrary files to programmatically analyze sounds stored on the computer."
         }
-    }
+    },
     "org.previewqt.PreviewQt": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"
@@ -9110,3 +9110,4 @@
         }
     }
 }
+

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8176,6 +8176,11 @@
             "finish-args-host-ro-filesystem-access": "Predates the linter rule"
         }
     },
+    "org.praat.Praat": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Scripts need to be able to access arbitrary files to programmatically analyze sounds stored on the computer."
+        }
+    }
     "org.previewqt.PreviewQt": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Praat is a tool for Linguistics that includes scripts for automatically analyzing large datasets of sounds, as well as accessing language models and other tools in the home directory. These cannot work with purely xdg-document-portals without massively rewriting the app and changing the script language, so it needs $HOME access to be properly packaged as a Flatpak.

Related PR: https://github.com/flathub/flathub/pull/8794

More info in the related issue: https://github.com/praat/praat.github.io/issues/2992