### PR TITLE
Add exception for page.codeberg.libre_menu_editor.LibreMenuEditor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8781,7 +8781,7 @@
             "finish-args-flatpak-spawn-access": "for reading environment variables on the host system",
             "finish-args-host-ro-filesystem-access": "Predates the linter rule",
             "finish-args-host-var-access": "Predates the linter rule",
-            "finish-args-unnecessary-xdg-config-mimeapps.list-create-access": "for reading and updating mimetypes in xdg-config/mimeapps.list",
+            "finish-args-arbitrary-xdg-config-create-access": "for reading and updating mimetypes in xdg-config/mimeapps.list, and creating file if not exist",
             "finish-args-unnecessary-xdg-data-applications-create-access": "for creating, reading, modifying, and deleting .desktop files in xdg-data/applications",
             "finish-args-unnecessary-xdg-data-flatpak-ro-access": "for reading .desktop files and symlink targets in xdg-data/flatpak",
             "finish-args-unnecessary-xdg-data-xdg-desktop-portal-ro-access": "for reading .desktop files and icons in xdg-data/xdg-desktop-portal"


### PR DESCRIPTION
The app needs to create/read/write the file ```~/.config/mimeapps.list```. I can not use ```--filesystem=xdg-config/mimeapps.list``` since the file will not exist on some distros. I can not use ```--filesystem=xdg-config/mimeapps.list:create```, as it will create a directory, breaking the app as well as other parts of the system. Instead, I need to use ```--filesystem=xdg-config:create``` and create the ```mimeapps.list``` file myself.