### PR TITLE
Add DataFlow home filesystem access exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4746,6 +4746,11 @@
             "finish-args-host-filesystem-access": "needed to access and modify projects outside of sandbox"
         }
     },
+    "io.github.sorguido.dataflow-procurement-software": {
+        "stable": {
+            "finish-args-home-filesystem-access": "DataFlow is a desktop procurement application that must preserve compatibility with its native Linux and Windows builds. XDG-only permissions were tested and caused an alternative sandboxed database to be created, breaking expected database persistence across restarts. The application manages SQLite database persistence, exports, backups, attachments, templates, and user-selected files. For the 2.3.0 Flatpak package, home access is required to preserve desktop-native behavior without application-level path handling changes."
+        }
+    },
     "io.github.sourcegit_scm.sourcegit": {
         "*": {
             "finish-args-has-socket-gpg-agent": "Needed to sign Git commits with GPG",


### PR DESCRIPTION
This adds a lint exception for `io.github.sorguido.dataflow-procurement-software`.

DataFlow is a desktop procurement application that must preserve compatibility with its native Linux and Windows builds.

The application manages SQLite database persistence, Excel/PDF exports, database backups, attachments, templates, and user-selected files/directories. For the 2.3.0 Flatpak package, `--filesystem=home` is required to preserve the expected desktop-native behavior.

A stricter XDG-only setup was tested by removing `--filesystem=home` and granting only:

- `--filesystem=xdg-documents:create`
- `--filesystem=xdg-download:create`
- `--filesystem=xdg-desktop:create`

That setup removes the lint error, but it breaks the expected application behavior: DataFlow creates an alternative sandboxed database, and a newly created RFQ does not remain persistent after restarting the application.

A more sandbox-friendly variant would require explicit application-level path handling changes for database/config persistence and user-selected file handling, which is outside the scope of the current 2.3.0 Flatpak package.
