### PR TITLE
Add exception for org.quetoo.Quetoo

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8246,8 +8246,7 @@
     },
     "org.quetoo.Quetoo": {
         "stable": {
-            "appstream-id-mismatch-flatpak-id": "appstream-cid predates this linter rule",
-            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+            "flathub-json-automerge-enabled": "Enabled as this is a game with low risk and low impact for breakage with new updates"
         }
     },
     "org.qxmledit.QXmlEdit": {


### PR DESCRIPTION
This game is currently being updated at a very fast pace, but the updates don't introduce large, breakage causing changes.
So the lead dev is interested in enabling automerge prs.
See full discussion in the last few comments of [this pr](https://github.com/flathub/org.quetoo.Quetoo/pull/13).

Also remove the other exceptions as they're now irrelevant.