### PR TITLE
Add io.itch.nordup.TheGates x11+wayland exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5069,6 +5069,11 @@
             "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"
         }
     },
+    "io.itch.nordup.TheGates": {
+        "stable": {
+            "finish-args-contains-both-x11-and-wayland": "The app spawns two separate Godot processes: a trusted launcher UI and a renderer process that loads untrusted remote world content. The launcher requires X11/XWayland because of native-Wayland UI bugs in Godot, while the renderer is deliberately run on native Wayland (--display-driver wayland) to isolate untrusted content from the rest of the session. fallback-x11 cannot satisfy this: on a Wayland session it hides the X11 socket, but the launcher needs X11 concurrently with the renderer's Wayland, so both sockets are required at the same time."
+        }
+    },
     "io.jamulus.Jamulus": {
         "*": {
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
Requesting an exception to `finish-args-contains-both-x11-and-wayland` for **io.itch.nordup.TheGates** (already published on Flathub).

### Why both sockets are needed simultaneously

The app spawns two separate Godot processes:

- **Launcher UI** (trusted) — needs **X11/XWayland** because of native-Wayland UI bugs in the Godot version it ships.
- **Renderer** (loads untrusted remote "world" content) — deliberately run on **native Wayland** (`--display-driver wayland`) so that potentially malicious content cannot snoop or inject into the rest of the session via the shared X11 socket.

`--socket=fallback-x11` cannot satisfy this: on a Wayland session it hides the X11 socket entirely, but the launcher needs X11 **concurrently** with the renderer's Wayland. Hence both `--socket=x11` and `--socket=wayland` are required at the same time.

The exception is scoped to the `stable` repo. App manifest PR using both sockets: flathub/io.itch.nordup.TheGates#100.