### PR TITLE
Update permissions for com.bitwarden.desktop to enable shared unlock / browser integration

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -437,7 +437,14 @@
         "stable": {
             "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
             "finish-args-contains-both-x11-and-wayland": "X11 access is needed for clipboard access",
-            "finish-args-login1-system-talk-name": "System talk access is needed to enable biometric / polkit unlock"
+            "finish-args-login1-system-talk-name": "System talk access is needed to enable biometric / polkit unlock",
+            "finish-args-flatpak-appdata-folder-com.google.Chrome-config-google-chrome-NativeMessagingHosts-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-flatpak-appdata-folder-org.chromium.Chromium-config-chromium-NativeMessagingHosts-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-flatpak-appdata-folder-com.microsoft.Edge-config-microsoft-edge-NativeMessagingHosts-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-flatpak-appdata-folder-org.mozilla.firefox-.mozilla-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-unnecessary-xdg-config-microsoft-edge-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-unnecessary-xdg-config-chromium-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-unnecessary-xdg-config-google-chrome-rw-access": "Needed to enable shared unlock / biometric unlock browser integration."
         }
     },
     "com.bitwig.BitwigStudio": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -436,8 +436,8 @@
     "com.bitwarden.desktop": {
         "stable": {
             "appid-ends-with-lowercase-desktop": "app-id predates this linter rule",
-            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-            "finish-args-login1-system-talk-name": "Predates the linter rule"
+            "finish-args-contains-both-x11-and-wayland": "X11 access is needed for clipboard access",
+            "finish-args-login1-system-talk-name": "System talk access is needed to enable biometric / polkit unlock"
         }
     },
     "com.bitwig.BitwigStudio": {


### PR DESCRIPTION
https://github.com/bitwarden/clients/pull/14836 added support for the browser integration for flatpak, which enables the biometric unlock (and soon shared unlock) in the browsers, when the bitwarden desktop app is packaged as a flatpak. The PR for pulling in the upstream permissions into the flathub build https://github.com/flathub/com.bitwarden.desktop/pull/320 is currently failing since the linting rules require to add exceptions for these permissions.

This PR updates the exceptions, granting the flathub build access to the native messaging hosts directories of chrome, chromium, firefox.

We intentionally scoped these as narrowly as we can instead of giving the desktop app access to the entire home directory, and to poke as little of a hole into the flatpak sandbox as possible.

As to the "temporary solution" aspect to of the policy, once efforts such as the NativeMessagingPortal mature, we will switch to these, and can then remove these permissions. Currently, there are no standards-based / portal based alternatives.



---

I've also taken the liberty to edit the generic notes for predating the permission into giving an actual reason for the existing permissions.