### PR TITLE
Add exception for HMCL to enable both X11 and Wayland.

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3550,6 +3550,11 @@
             "finish-args-login1-system-talk-name": "Needed for the PrepareForSleep signal from logind to cleanly tear down active streaming sessions on suspend. No portal equivalent exists for this signal."
         }
     },
+    "io.github.HMCL_dev.HMCL": {
+        "stable": {
+            "finish-args-contains-both-x11-and-wayland": "This is required because some Minecraft builds support wayland but HMCL doesn't support wayland."
+        }
+    },
     "io.github.ImEditor": {
         "*": {
             "appid-code-hosting-too-few-components": "app-id predates this linter rule"


### PR DESCRIPTION
The exception is needed because:

Some minecraft builds support wayland because of modified GLFW.
HMCL uses JavaFX so it doesn't support Wayland.

So in some cases, the program needs both Wayland and X11 to function properly.