### PR TITLE
Add X11+Wayland exception for com.dekomote.vermouth

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -574,7 +574,8 @@
     },
     "com.dekomote.vermouth": {
         "stable": {
-            "finish-args-home-filesystem-access": "Required for umu and Proton to run the games, scan for runtimes and retroarch cores"
+            "finish-args-home-filesystem-access": "Required for umu and Proton to run the games, scan for runtimes and retroarch cores",
+            "finish-args-contains-both-x11-and-wayland": "A lot of Linux games, still use SDL<2 bundled which lacks wayland driver. Proton runtime has experimental wayland support only."
         }
     },
     "com.devolutions.remotedesktopmanager": {


### PR DESCRIPTION
A lot of older Linux games come with old SDL bundled which doesn't have a wayland driver and they fail to launch if the X11 socket is unavailable on a wayland system. Furthermore, Proton only has experimental wayland support and it's often buggy.