### PR TITLE
Update permissions for com.orcaslicer.OrcaSlicer

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -9051,7 +9051,7 @@
     "com.orcaslicer.OrcaSlicer": {
         "stable": {
             "finish-args-home-filesystem-access": "OrcaSlicer needs persistent access to model files, recent projects, and G-code export across arbitrary user directories",
-            "finish-args-flatpak-appdata-folder-io.github.orcaslicer.OrcaSlicer-ro-access": "Read-only access to legacy config/cache directory (~/.var/app/io.github.orcaslicer.OrcaSlicer) for migration from old app-id"
+            "finish-args-flatpak-appdata-folder-io.github.softfever.OrcaSlicer-ro-access": "Read-only access to legacy config/cache directory (~/.var/app/io.github.softfever.OrcaSlicer) for migration from old app-id"
         }
     },
     "org.cvfosammmm.Lemma": {


### PR DESCRIPTION
OrcaSlicer was trying to migrate old configs from an `io.github.orcaslicer.OrcaSlicer` folder — a bundle ID used only in nightly builds between the 2.3.1 and 2.3.2 releases.
The correct old config folder, widely used in pre-2.3.2 releases, is `io.github.softfever.OrcaSlicer`.

This PR fixes the issue.

Fix https://github.com/flathub/com.orcaslicer.OrcaSlicer/issues/1
