### PR TITLE
Add finish-args-flatpak-spawn-access exception for io.kinvolk.Headlamp

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5058,7 +5058,8 @@
     },
     "io.kinvolk.Headlamp": {
         "stable": {
-            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"
+            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+            "finish-args-flatpak-spawn-access": "Required to spawn kubelogin/az/aws/helm etc for headlamp to work with different auth providers"
         }
     },
     "io.kopia.KopiaUI": {


### PR DESCRIPTION
Headlamp is a Kubernetes desktop UI. Cluster authentication relies on kubeconfig exec credential plugins (client-go), which invoke host binaries such as `kubelogin` (Azure AD), the `aws` CLI (EKS), `gke-gcloud-auth-plugin` etc. These binaries are not present inside the sandbox, so `flatpak-spawn` access to the host is required for auth to work with different providers.

Corresponding manifest PR: flathub/io.kinvolk.Headlamp#77