### PR TITLE
Add vkSumi exception for GOverlay

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3551,7 +3551,8 @@
         "stable": {
             "finish-args-flatpak-appdata-folder-com.valvesoftware.Steam-rw-access": "Needed for reading Steam and other applications\u2019 MangoHud configuration",
             "finish-args-unnecessary-xdg-config-MangoHud-rw-access": "Needed for reading MangoHud config files",
-            "finish-args-unnecessary-xdg-config-vkBasalt-rw-access": "Needed for reading vkBasalt config files"
+            "finish-args-unnecessary-xdg-config-vkBasalt-rw-access": "Needed for reading vkBasalt config files",
+            "finish-args-unnecessary-xdg-config-vkSumi-rw-access": "Needed for reading vkSumi config files"
         }
     },
     "io.github.bkbilly.lnxlink": {


### PR DESCRIPTION
This exception is needed in order for goverlay configure the global config file for vksumi