### PR TITLE
Add com.bitwarden.desktop shared unlock permissions for Brave and Vivaldi

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -415,7 +415,9 @@
             "finish-args-flatpak-appdata-folder-org.mozilla.firefox-.mozilla-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
             "finish-args-unnecessary-xdg-config-microsoft-edge-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
             "finish-args-unnecessary-xdg-config-chromium-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
-            "finish-args-unnecessary-xdg-config-google-chrome-rw-access": "Needed to enable shared unlock / biometric unlock browser integration."
+            "finish-args-unnecessary-xdg-config-google-chrome-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-unnecessary-xdg-config-BraveSoftware-rw-access": "Needed to enable shared unlock / biometric unlock browser integration.",
+            "finish-args-unnecessary-xdg-config-vivaldi-rw-access": "Needed to enable shared unlock / biometric unlock browser integration."
         }
     },
     "com.bitwig.BitwigStudio": {


### PR DESCRIPTION
Needed to support https://github.com/flathub/com.bitwarden.desktop/pull/327, which fixes https://github.com/bitwarden/clients/issues/21519.

Support for these 2 browsers was added in https://github.com/bitwarden/clients/commit/4d62a123cc443abbce3d3f197928291b620be62a.