### PR TITLE
Add finish-args-flatpak-spawn-access exception for io.github.zoutmax.FifineControlDeck

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4694,6 +4694,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.zoutmax.FifineControlDeck": {
+        "stable": {
+            "finish-args-flatpak-spawn-access": "macro keypad controller: user-configured key actions (launch apps, run commands, hotkeys via host ydotool/xdotool, media/volume via playerctl/wpctl) run on the host, like com.core447.StreamController"
+        }
+    },
     "io.github.zyedidia.micro": {
         "stable": {
             "finish-args-flatpak-spawn-access": "users may want to use it for built-in terminal emulator",


### PR DESCRIPTION
For the new-app submission flathub/flathub#9390 (fifine Control Deck — a native Linux controller for fifine AmpliGame D6 / Mirabox Stream Dock macro keypads).

The app's core purpose is executing user-configured key actions on the host: launching applications, running commands, sending hotkeys via host ydotool/xdotool, and media/volume via playerctl/wpctl — all via `flatpak-spawn --host`. Without it the app can only render key images.

Precedent: com.core447.StreamController (same app category, "required to allow plugins to open apps on the host"), app.devsuite.Ptyxis, ca.vtrlx.Telepipe, and other host-action apps carrying this exception.

The submission's test build currently fails only on this linter check.