### PR TITLE
Add exceptions for io.github.ScarletPachydermDev.Gridge

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3410,6 +3410,13 @@
             "flathub-json-automerge-enabled": "Predates the linter rule"
         }
     },
+    "io.github.ScarletPachydermDev.Gridge": {
+        "stable": {
+            "finish-args-flatpak-spawn-access": "Needs flatpak-spawn --host to restart Steam on the host after creating/updating non-Steam shortcuts, and to detect/launch natively-installed Steam and Microsoft Edge",
+            "finish-args-flatpak-appdata-folder-rw-access": "Needs ~/.var/app access broader than a single app because Flatpak filesystem grants are bound at sandbox creation time: a grant scoped to one app's data folder never becomes visible if that app wasn't installed yet when the sandbox started, which breaks first-run onboarding (installing Steam/Edge as Flatpaks from within Gridge itself). Confirmed by testing the narrower per-app grant and reproducing the failure.",
+            "finish-args-unnecessary-xdg-data-Steam-rw-access": "Needed for native (non-Flatpak) Steam installs at ~/.local/share/Steam -- confirmed by testing removal: ~/.steam/steam is a symlink into this directory, and Flatpak filesystem grants don't make a symlink's target visible unless the target itself is separately granted."
+        }
+    },
     "io.github.Sunderland93.sway-input-config": {
         "stable": {
             "finish-args-unnecessary-xdg-config-sway-rw-access": "Required to access Sway configuration on host"


### PR DESCRIPTION
Hey

Requesting exceptions for three linter findings on my [Flathub submission](https://github.com/flathub/flathub/pull/9396) (`io.github.ScarletPachydermDev.Gridge`). Each was tested directly on real hardware, not just assumed necessary:

`finish-args-flatpak-spawn-access `— Gridge needs to restart Steam on the host after writing/updating non-Steam shortcuts (so the new shortcuts actually show up in Steam's library), and to detect and launch natively-installed Steam and Microsoft Edge from inside the sandbox.` flatpak-spawn --host` is the standard mechanism for this.
`
finish-args-flatpak-appdata-folder-rw-access `— Gridge can install Steam and/or Microsoft Edge itself (as Flatpaks) during first-run onboarding if either is missing. Flatpak filesystem grants are resolved at sandbox creation time: a grant scoped to one specific app's data folder (e.g. `~/.var/app/com.valvesoftware.Steam`) never becomes visible if that folder didn't exist yet when Gridge's own sandbox started — even after the app gets installed moments later in the same session. I confirmed this by testing the narrower per-app grant directly: onboarding could install Steam successfully, but Gridge could never detect it afterward without a full app restart. The broader `~/.var/app `grant is what makes first-run onboarding actually work.

`finish-args-unnecessary-xdg-data-Steam-rw-access` — Needed for native (non-Flatpak) Steam installs at `~/.local/share/Steam`. I tested removing this grant: `~/.steam/steam` is a symlink into that directory, and Flatpak filesystem grants don't make a symlink's target visible unless the target path is separately granted — so native Steam detection broke without it.