### PR TITLE
Add mimeapps.list:ro exception for com.fightcade.Fightcade

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -617,7 +617,8 @@
     },
     "com.fightcade.Fightcade": {
         "*": {
-            "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function"
+            "flathub-json-automerge-enabled": "Predates the linter rule, outdated clients cannot function",
+            "finish-args-unnecessary-xdg-config-mimeapps.list-ro-access": "Read-only access to the host's mimeapps.list is used solely to detect a conflicting non-Flatpak Fightcade install at startup, by checking whether the fcade:// URL-scheme default handler is one other than the Flatpak's own com.fightcade.Fightcade.fcade-quark.desktop, then warn the user, since running both installs breaks fcade:// challenge-URL launching (flathub/com.fightcade.Fightcade#126). No files are written or executed."
         }
     },
     "com.flashforge.FlashPrint": {


### PR DESCRIPTION
Fightcade's Flatpak needs read-only access to ~/.local/share/applications to detect whether a conflicting non-Flatpak ("desktop") Fightcade install is also present. When both are installed they contend over the fightcade:// URL-scheme handler and challenge URLs stop launching correctly (see flathub/com.fightcade.Fightcade#126).

The access is strictly read-only and used only to check for two specific files (Fightcade.desktop, fcade-quark.desktop) and show a zenity warning. Nothing is written or executed.