### PR TITLE
Add exception for io.github.anil_e.Codd

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3505,6 +3505,11 @@
             "finish-args-host-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.anil_e.Codd": {
+        "stable": {
+            "finish-args-has-socket-ssh-auth": "Needed for SSH agent authentication in PostgreSQL tunnel connections"
+        }
+    },
     "io.github.antimicrox.antimicrox": {
         "*": {
             "finish-args-home-filesystem-access": "Required until https://github.com/flatpak/xdg-desktop-portal-gtk/issues/191 is fixed"


### PR DESCRIPTION
Codd now supports SSH tunnels for PostgreSQL connections. The ssh-auth socket is needed so users can authenticate those tunnels with their existing SSH agent instead of selecting private key files inside the app.