### PR TITLE
Add exception for com.dygma.bazecor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -564,6 +564,11 @@
             "finish-args-host-filesystem-access": "Predates the linter rule"
         }
     },
+    "com.dygma.bazecor": {
+        "stable": {
+            "finish-args-host-etc-ro-filesystem-access": "Required to alert users if /etc/udev/rules.d/60-dygma.rules is missing/outdated and instruct the user to manually add/update it"
+        }
+    },
     "com.dingtalk.DingTalk": {
         "stable": {
             "finish-args-own-name-wildcard-org.kde": "Still uses legacy StatusNotifier implementation"


### PR DESCRIPTION
[Bazecor](https://github.com/Dygmalab/Bazecor) is the graphical configurator for the Dygma Raise & Defy mechanical keyboards. The project started in 2019 and was first released in Febuary 2020.

Dygma UX design for Bazecor on Linux have requirements to check:

- if /etc/udev/rules.d/60-dygma.rules is present, and
- if /etc/udev/rules.d/60-dygma.rules is up-to date.

If the file is either missing or if it is outdated, this dialog prompt appears to the user at launch:

<img width="1195" height="920" alt="image" src="https://github.com/user-attachments/assets/2ea90bbe-ebfd-41d9-ab25-d93bbe26c658" />

In order for Bazecor to access /run/host/etc/udev/rules.d/60-dygma.rules to meet their UX requirements, we request permission to use the `--filesystem=host-etc:ro` flag. Without this flag, the app assumes that the file is always missing and will always show this dialogue to the user at launch.

Of course, pressing on the "Install" button won't work inside flatpak symbox, but we are currently planning to modify the Intall error dialog to show instructions the user on how to fix the problem manually:

<img width="1200" height="960" alt="image" src="https://github.com/user-attachments/assets/21cc0543-86a6-4b13-9289-ea35db8af72b" />

We only require access to `/etc/udev/rules.d/60-dygma.rules`. and no other files. If there is a better way than getting complete read-access to the entire `/etc` folder structure, please let us know and we'll change the flatpak builder manifest accordingly.

Thanks!
