### PR TITLE
Update exceptions for net.cozic.joplin_desktop

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5143,7 +5143,8 @@
     "net.cozic.joplin_desktop": {
         "*": {
             "external-gitmodule-url-found": "Predates the linter rule",
-            "finish-args-home-filesystem-access": "Predates the linter rule"
+            "finish-args-home-filesystem-access": "Predates the linter rule",
+            "finish-args-unnecessary-xdg-config-joplin-desktop-create-access": "Joplin hardcodes its config path outside XDG_CONFIG_HOME and creates the directory on first run"
         }
     },
     "net.daase.journable": {


### PR DESCRIPTION
The Joplin flatpak currently has broad access to the home directory which it doesn't need.

I've created a PR to narrow its access to the directories it actually creates: https://github.com/flathub/net.cozic.joplin_desktop/pull/328

However, the build for that PR is failing due to the linter. This PR adds the exception required for the scoped rules.