### PR TITLE
Update exceptions for net.cozic.joplin_desktop

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5142,8 +5142,7 @@
     },
     "net.cozic.joplin_desktop": {
         "*": {
-            "external-gitmodule-url-found": "Predates the linter rule",
-            "finish-args-home-filesystem-access": "Predates the linter rule"
+            "external-gitmodule-url-found": "Predates the linter rule"
         }
     },
     "net.daase.journable": {


### PR DESCRIPTION
The Joplin flatpak currently has broad access to the home directory which it doesn't need.

I've created a PR to narrow its access to the directories it actually creates: https://github.com/flathub/net.cozic.joplin_desktop/pull/328

This PR removes the exception for broad home access.