### PR TITLE
Add exceptions for com.danklinux.dankcalendar

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -532,6 +532,12 @@
             "finish-args-home-ro-filesystem-access": "Predates the linter rule"
         }
     },
+    "com.danklinux.dankcalendar": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Local calendars use ICS directories chosen anywhere under the user's home.",
+            "finish-args-login1-system-talk-name": "Watch PrepareForSleep so reminders fire correctly after suspend."
+        }
+    },
     "com.darhon.syncbackup": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Related to flathub/flathub#9458

App submission: https://github.com/flathub/flathub/pull/9458

Requesting two finish-args exceptions:
- finish-args-home-filesystem-access: users pick local ICS calendar directories anywhere under $HOME
- finish-args-login1-system-talk-name: subscribe to login1 PrepareForSleep so reminders still fire after suspend

Thanks, Purian23!