### PR TITLE
Add exception for io.github.cosmic_utils.camera

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3607,6 +3607,11 @@
             "finish-args-flatpak-spawn-access": "the app predates this linter rule"
         }
     },
+    "io.github.cosmic_utils.camera": {
+        "stable": {
+            "finish-args-login1-system-talk-name": "System bus access to org.freedesktop.login1 (logind Inhibit) keeps idle lock and suspend from interrupting an active camera session"
+        }
+    },
     "io.github.cosmic_utils.Examine": {
         "stable": {
             "finish-args-unnecessary-xdg-config-cosmic-ro-access": "Required to read the system theme and listen for config changes in the host"


### PR DESCRIPTION
The upcoming version v1.0.0 of the Camera application added a feature to prevent the system from sleeping and locking when the Camera application is in use.