### PR TITLE
Filesystem exception for org.mpz_player.mpz

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7683,7 +7683,7 @@
     },
     "org.mpz_player.mpz": {
         "stable": {
-            "finish-args-host-filesystem-access": "Folder-based music player: users add arbitrary directories (external drives, NFS-shares, etc) which mpz reads, watches for changes (QFileSystemModel, inotify), plus there is built-in tag editor and playlists export"
+            "finish-args-home-filesystem-access": "Folder-based music player: reads and watches user-picked music dirs recursively (QFileSystemModel, inotify), which portals cannot do; also tag editing and playlist export"
         }
     },
     "org.musescore.MuseScore": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7676,6 +7676,11 @@
             "finish-args-own-name-wildcard-org.mozilla.thunderbird": "Thunderbird ESR uses the same dbus name as monthly release"
         }
     },
+    "org.mpz_player.mpz": {
+        "stable": {
+            "finish-args-host-filesystem-access": "Folder-based music player: users add arbitrary directories (external drives, NFS-shares, etc) which mpz reads, watches for changes (QFileSystemModel, inotify), plus there is built-in tag editor and playlists export"
+        }
+    },
     "org.musescore.MuseScore": {
         "*": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Without full filesystem access this player becomes too crippled to justify its existence on Flathub:
- music can be scattered all over the place, on network shares, external drives, etc, I have 4 different folders, for example
- QFileSystemWatcher uses inotify, which is needed to pick up the changes in library folders

It's been around for many years with existing userbase
https://github.com/olegantonyan/mpz