### PR TITLE
Add exceptions for io.github.wyze3306.BedrockOnLinux

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4673,6 +4673,13 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.wyze3306.BedrockOnLinux": {
+        "stable": {
+            "finish-args-contains-both-x11-and-wayland": "The GUI crashes with an unset $DISPLAY under --socket=fallback-x11 in pure-Wayland sessions. --socket=x11 is required alongside --socket=wayland.",
+            "finish-args-flatpak-spawn-access": "The game runs through umu-launcher & Steam Linux Runtime, which spawns its sub-sandbox via the Flatpak portal",
+            "finish-args-unnecessary-xdg-data-bedrock-on-linux-ro-access": "One-time read-only access to the pre-Flatpak data directory for migrating existing installs. The app atomically copies it to private XDG storage before writing. This permission is transitional and will be removed in a later release."
+        }
+    },
     "io.github.xiaoyifang.goldendict_ng": {
         "stable": {
             "flathub-json-automerge-enabled": "Predates the linter rule"


### PR DESCRIPTION
I need a linter exception entry for io.github.wyze3306.BedrockOnLinux (https://github.com/Wyze3306/BedrockOnLinux), a launcher for running Minecraft Bedrock Edition on Linux via Wine/UMU, ahead of its Flathub submission.

Three things need an exception:

- finish-args-contains-both-x11-and-wayland: The launcher GUI is written in Tkinter which is X11-only. Under a Wayland session --socket=fallback-x11 leaves $DISPLAY unset and tk.Tk() crashes on startup. --socket=x11 is required unconditionally & --socket=wayland is used by the game itself via XWayland.

- finish-args-flatpak-spawn-access: The game runs through umu-launcher  & pressure-vessel which spawns its own sub-sandbox via the Flatpak portal. This is the same permission set already used by Lutris, Bottles, & Heroic for the same reason.

- finish-args-unnecessary-xdg-data-bedrock-on-linux-ro-access: One-time, read-only access to the app's pre-Flatpak data directory (~/.local/share/bedrock-on-linux) to support migrating existing non-Flatpak installs. The app atomically copies this data into private XDG storage on first run and never writes back to the old location. This permission is transitional and will be removed once the migration window closes in a future release.