### PR TITLE
add exception for io.github.AllanChain.sane-break

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3273,6 +3273,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.AllanChain.sane-break": {
+        "stable": {
+            "finish-args-login1-system-talk-name": "Needed for detecting idle inhibitors and account them as activity instead of idle."
+        }
+    },
     "io.github.Archeb.opentrace": {
         "stable": {
             "finish-args-flatpak-spawn-access": "This app uses org.freedesktop.Flatpak to provide ability to run nexttrace with cap_net_raw, which is necessary for a traceroute app"


### PR DESCRIPTION
Idle inhibitors (e.g., keeping the display on for video playback) indicate active computer use. Treating these inhibitors as user activity to disable "auto pause on idle" is a better way to track the time. `org.freedesktop.login1` is needed to reliably detect idle inhibitors.

Context:

- https://github.com/AllanChain/sane-break/issues/157
- https://github.com/AllanChain/sane-break/pull/159
- https://github.com/flathub/io.github.AllanChain.sane-break/pull/39