### PR TITLE
`finish-args-contains-both-x11-and-wayland` exception for `org.squidowl.halloy`

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8753,5 +8753,10 @@
             "finish-args-host-filesystem-access": "SFTP client needs direct access to user-chosen local paths outside home (removable media, /mnt, /srv, project trees) for transfer, sync, and directory-watch operations. FileChooser portal is used where the user picks individual files, but background transfers and watched directories need persistent access to the chosen paths.",
             "finish-args-has-socket-ssh-auth": "Required to use the user's running SSH agent for public-key authentication against remote hosts (the standard mechanism for yubikey/gpg-agent/passphrase-protected keys)."
         }
+    },
+    "org.squidowl.halloy": {
+        "stable": {
+            "finish-args-contains-both-x11-and-wayland": "Required because iced's clipboard library (arboard) currently requires wayland-data-control, and currently needs access to the x11 socket for fallback when wayland-data-control is not available."
+        }
     }
 }


### PR DESCRIPTION
Halloy uses [iced-rs](https://github.com/iced-rs/iced) which uses [arboard](https://github.com/1Password/arboard) to provide clipboard access.

Arboard has [an issue](https://github.com/1Password/arboard/issues/223) with it's wayland support right now. Seems they have noted it on [their readme](https://github.com/1Password/arboard#backend-support) as well.

Currently, if we only have `x11` socket, Halloy will crash for elementaryOS users. With `fallback-x11` and `wayland`, clipboard access is denied to Gnome users.

Seems the only way our app won't crash and has clipboard access across the desktop environments, are to use both `x11` and `wayland` sockets together.

Tagging @barthalion to review the exception requested here :pray: 