### PR TITLE
Add finish-args-home-filesystem-access exception for no.mifi.losslesscut

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5541,6 +5541,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "no.mifi.losslesscut": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Video editor that writes its export output into the same directory as the source file. The Electron app does not use the document portal for these paths, so exports of files outside the XDG directories are staged as hidden .xdp-* files that are never renamed, while the app reports success and the user sees no output."
+        }
+    },
     "one.ablaze.floorp": {
         "stable": {
             "finish-args-own-name-wildcard-org.mozilla.floorp": "Predates the linter rule",


### PR DESCRIPTION
Requesting `finish-args-home-filesystem-access` for `no.mifi.losslesscut`.

This unblocks flathub/no.mifi.losslesscut#107, which currently fails `validate-manifest` on this check.

## Why the app needs it

LosslessCut writes its export output **into the same directory as the source file** — that is the core interaction of the app, not a configurable convenience. It is an Electron app that does not use the document portal for these paths; the manifest has carried the comment `# Electron cannot do portals :(` since the initial packaging, with three `xdg-*` directories allowlisted as a workaround.

That workaround only holds for users who keep footage in `~/Downloads`, `~/Public` or `~/Videos`. For anyone else the failure is **silent, and looks like data loss**:

- the file picker hands the app a document-portal proxy path rather than a real one
- the export is staged into the real directory as a hidden `.xdp-<name>-<random>` file
- the portal's final rename never happens, so nothing appears under the expected name
- ffmpeg exits 0, so the app reports a successful export

I hit this with footage in `~/projects/`. Two complete 40-minute exports (1.1 GB each, `ffprobe` confirms `duration=2428.281667`) were sitting in the directory the whole time as:

```
.xdp-20190101_000011B-cut-merged-1786116241623.mp4-h4t741
.xdp-20190101_000011B-cut-merged-1786116636011.mp4-NukuEW
```

I only found them by inspecting the directory with `ls -la`. "Export project" fails the same way. Reported upstream as mifi/lossless-cut#3003.

## Why not narrower

Widening to more XDG directories (`xdg-documents`, `xdg-pictures`, `xdg-desktop`) does not solve it — the problem is precisely that users keep video projects in arbitrary directories, and a video editor cannot know in advance where a user's media lives. `home` was chosen over `host` deliberately, so system paths and mounted external drives remain outside the sandbox.

## Precedent

This matches existing granted exceptions closely:

- `it.andreafontana.hideout` — *"Encryption utility that needs to save encrypted/decrypted output files in the same location as the source files."*
- `me.fouquet.Stencil` — *"The document portal provides no rename operation, so direct home filesystem access is required to rename files in place"*
- `com.abisource.AbiWord` — *"Doesn't use portals"*

## Disclosure

I am not the maintainer of the Flathub package — I hit this as a user, diagnosed it, and opened flathub/no.mifi.losslesscut#107. Happy to defer if you would rather the packager drive the request, or to adjust the wording.
