### PR TITLE
Add exceptions for io.github.Faugus.faugus-launcher

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3307,7 +3307,8 @@
             "finish-args-contains-both-x11-and-wayland": "Without socket=X11 Winetricks doesn't work on Wayland and without socket=wayland the Wine Wayland driver doesn't work.",
             "finish-args-home-filesystem-access": "Predates the linter rule",
             "finish-args-unnecessary-xdg-config-MangoHud-ro-access": "Required by MangoHud to detect the settings file.",
-            "finish-args-own-name-wildcard-com.steampowered": "Required by umu-launcher to access the Steam Runtime's pressure-vessel."
+            "finish-args-own-name-wildcard-com.steampowered": "Required by umu-launcher to access the Steam Runtime's pressure-vessel.",
+            "finish-args-flatpak-spawn-access": "Required to relaunch this app's own id via 'flatpak run' as a separate sandbox instance for the optional tray helper; a plain child process makes the systray draw a duplicate icon."
         }
     },
     "io.github.Foldex.AdwSteamGtk": {


### PR DESCRIPTION
This is for the optional system tray icon. When the main window is closed with tray enabled, the app hands off to a tiny helper process instead of staying fully resident just to show an icon.

The only command that ever runs through `flatpak-spawn` is:
`flatpak-spawn --host flatpak run --command=python3 io.github.Faugus.faugus-launcher -m faugus.tray_only`

Always this exact string, always this app's own id, nothing user-controlled goes into it. It's not arbitrary host access, just relaunching through flatpak under the same sandbox restrictions as a normal launch.

The separate instance is needed because a plain child process (no special permission, sharing the main app's sandbox) doesn't work: closing the window causes the systray to draw a second, dead icon alongside the real one. A few things were tried before reaching for `flatpak-spawn`: Reordering the D-Bus environment, making it idempotent, a graceful quit instead of a hard exit, requesting the Background portal. None of that got rid of it; only giving the helper its own sandbox instance did.