### PR TITLE
Create exceptions for OpenRGB host access for udev rules checks

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7791,6 +7791,12 @@
             "finish-args-host-filesystem-access": "Predates the linter rule"
         }
     },
+    "org.openrgb.OpenRGB": {
+        "*": {
+            "finish-args-host-etc-ro-filesystem-access": "Required to alert users if /etc/udev/rules.d/60-openrgb.rules is missing and instruct tue suer to manually add it",
+            "finish-args-host-ro-filesystem-access": "Required to alert users if /usr/lib/udev/rules.d/60-openrgb.rules is missing and instruct tue suer to manually add it"
+        }
+    },
     "org.openscad.OpenSCAD": {
         "*": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
I added support for udev rules checks a while ago in OpenRGB, but they have been failing on the Flatpak version ever since due to the lack of host filesystem access.  OpenRGB, by its nature of being a hardware control application targeting a large variety of different hardware devices, requires a udev rules file be installed for it to be able to control most of the devices it supports.  This includes a lot of USB HID devices as well as things like user i2c-dev access.  OpenRGB's flatpak already has device access, but I want to update it to be able to properly check for the udev rules.  It needs both host (/usr) and host-etc (/etc) because the udev rules could be in either /etc/udev/rules.d or /usr/lib/udev/rules.d.  It checks both paths for the existence of 60-openrgb.rules and shows a warning if either neither path exists or both paths exist.

OpenRGB uses the stable and beta branches so I used the wildcard to cover both.  I hope that is OK.