### PR TITLE
Fix exceptions for org.gimp.GIMP

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -6233,7 +6233,7 @@
             "finish-args-host-filesystem-access": "Predates the linter rule",
             "finish-args-host-tmp-access": "Predates the linter rule",
             "finish-args-unnecessary-xdg-config-GIMP-create-access": "GIMP config always used",
-            "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "gtk-3.0 and GIMP config."
+            "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "For reading desktop theme and gtk bookmarks."
         }
     },
     "org.gitfourchette.gitfourchette": {


### PR DESCRIPTION
Granting rw access is common mistake as 99% of apps are fine with ro.