### PR TITLE
Add login1 exception for com.github.IsmaelMartinez.teams_for_linux

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -736,7 +736,8 @@
     "com.github.IsmaelMartinez.teams_for_linux": {
         "stable": {
             "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-            "finish-args-home-filesystem-access": "Predates the linter rule"
+            "finish-args-home-filesystem-access": "Predates the linter rule",
+            "finish-args-login1-system-talk-name": "Electron's powerMonitor needs PrepareForSleep from login1 for its resume handlers; no portal exposes this signal."
         }
     },
     "com.github.KRTirtho.Spotube": {


### PR DESCRIPTION
teams-for-linux's resume handlers are dead in the Flatpak: Electron's `powerMonitor` needs `PrepareForSleep` from `org.freedesktop.login1`, which the sandbox blocks. They refresh the Teams connection (`app/connectionManager/index.js:46`) and clear expired auth cookies (`app/mainAppWindow/index.js:1277`) after wake, and work on every other channel. No portal exposes the signal, and talk-name granularity is per bus name.

Manifest change: flathub/com.github.IsmaelMartinez.teams_for_linux#211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
