### PR TITLE
Add exception for me.chocolateimage-graphics-creator

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8759,5 +8759,10 @@
         "stable": {
             "finish-args-contains-both-x11-and-wayland": "Required because iced's clipboard library (arboard) currently requires wayland-data-control, and currently needs access to the x11 socket for fallback when wayland-data-control is not available."
         }
+    },
+    "me.chocolateimage.graphics-creator": {
+        "stable": {
+            "finish-args-host-filesystem-access": "Loads assets from locations in home or mounted directories specified in project files."
+        }
     }
 }


### PR DESCRIPTION
Project files contain paths to assets that are located anywhere on disk (can be images, and other assets too).

The project file can also be modified to have any path as an asset file (for example if you make a script that automatically changes the file and then render automatically).

This is why this exception is needed.