### PR TITLE
Add finish-args-host-var-access exception for io.github.idescriptor.iDescriptor

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8759,5 +8759,10 @@
         "stable": {
             "finish-args-contains-both-x11-and-wayland": "Required because iced's clipboard library (arboard) currently requires wayland-data-control, and currently needs access to the x11 socket for fallback when wayland-data-control is not available."
         }
+    },
+    "io.github.idescriptor.iDescriptor": {
+        "stable": {
+            "finish-args-host-var-access": "Required to connect to wireless devices, usbmuxd doesn't handle/recognize wireless devices on Linux and Windows."
+        }
     }
 }


### PR DESCRIPTION
Hi, this exception is required for https://github.com/flathub/flathub/pull/9691

**Why**
- usbmuxd doesn't handle/recognize wireless devices on Linux and Windows.
- usbmuxd doesn't provide pairing record enumeration directly (meaning there is no way I can see what pairing files the user has through usbmuxd)
- the app must be able to read the pairing files so we can connect

**Solution**: `--filesystem=/var/lib/lockdown:ro` (readonly)

