### PR TITLE
Add exceptions for nz.net.jonesie.Costree

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1,4 +1,12 @@
 {
+    "nz.net.jonesie.Costree": {
+        "stable": {
+            "finish-args-host-filesystem-access": "CosTree is a disk usage analyzer that needs to scan, rename, and delete arbitrary files anywhere on disk, not just its own sandbox or home directory -- same justification org.gnome.baobab has for this exception",
+            "finish-args-flatpak-appdata-folder-rw-access": "Lets CosTree also measure other Flatpak apps' data directories, consistent with org.gnome.baobab",
+            "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to read and write libcosmic's cosmic_config app settings, consistent with com.vkhitrin.cosmicding and dev.edfloreshz.CosmicTweaks",
+            "finish-args-flatpak-spawn-access": "Uses flatpak-spawn --host to launch cosmic-files/xdg-open on the host for the right-click Open action, since these can not be resolved as sandboxed binaries"
+        }
+    },
     "ai.opencode.opencode": {
         "*": {
             "finish-args-home-filesystem-access": "Needed to access and modify projects outside the sandbox"


### PR DESCRIPTION
Requesting exceptions for [nz.net.jonesie.Costree](https://github.com/Jonesie/costree), a graphical disk usage analyzer for the COSMIC desktop (libcosmic), currently submitting to Flathub.

Four exceptions requested, each with direct precedent from already-accepted apps:

| Exception | Precedent | Why |
|---|---|---|
| `finish-args-host-filesystem-access` | `org.gnome.baobab` | Closest functional analog — a disk usage analyzer needs to see the whole disk to be useful. CosTree also renames/deletes files (baobab doesn't), so the need is at least as strong. |
| `finish-args-flatpak-appdata-folder-rw-access` | `org.gnome.baobab` | Lets CosTree also measure other Flatpak apps' `~/.var/app` data directories. |
| `finish-args-unnecessary-xdg-config-cosmic-rw-access` | `com.vkhitrin.cosmicding`, `dev.edfloreshz.CosmicTweaks` | libcosmic's `cosmic_config` persists app settings there — same as both existing libcosmic Flatpaks. |
| `finish-args-flatpak-spawn-access` | `app.devsuite.Ptyxis` | Needed for `flatpak-spawn --host` to launch `cosmic-files`/`xdg-open` on the host for the right-click "Open" action, since a sandboxed process can't resolve those binaries by name. |

Source: https://github.com/Jonesie/costree