### PR TITLE
Add finish-args-home-filesystem-access exception for cn.eeo.ClassIn

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -275,6 +275,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "cn.eeo.ClassIn": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Needed because the proprietary Qt-based file picker cannot access through symlinks, and allow users to select files from the root of their home directory."
+        }
+    },
     "cn.ottercorp.xivlaunchercn": {
         "stable": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Hi Flathub reviewers, this exception is required for https://github.com/flathub/flathub/pull/9708

**Why**
- ClassIn uses a proprietary Qt-based file picker instead of the native XDG Desktop Portal. 
- Due to this, it cannot open files via symlinks, which prevents users from reading, uploading classroom materials (documents, images, videos), or saving downloaded assignments or recorded class sessions that stored in external drives or home folder.
- Allows users/students to uploading files on root of their home folder, especially if they are joining a proramming class, because they often use Git.

**Solution**: `--filesystem=home`

