### PR TITLE
Widen com.github.IsmaelMartinez.teams_for_linux exceptions to all repos

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -734,7 +734,7 @@
         }
     },
     "com.github.IsmaelMartinez.teams_for_linux": {
-        "stable": {
+        "*": {
             "appid-uses-code-hosting-domain": "app-id predates this linter rule",
             "finish-args-home-filesystem-access": "Predates the linter rule",
             "finish-args-login1-system-talk-name": "Electron's powerMonitor needs PrepareForSleep from login1 for its resume handlers; no portal exposes this signal."


### PR DESCRIPTION
The app is adding a `beta` branch to publish upstream pre-releases, and its three existing exceptions apply there too, so this scopes them with `*` rather than `stable`. No new rules are requested, and the branch does not exist yet because the first beta build would otherwise fail on rules already granted for stable. Beta builds would run roughly weekly to fortnightly, matching the project's release cadence.

Manifest repo: flathub/com.github.IsmaelMartinez.teams_for_linux
