### PR TITLE
Update `io.github.ilya_zlobintsev.LACT` permissons for host service setup

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3864,7 +3864,8 @@
     },
     "io.github.ilya_zlobintsev.LACT": {
         "stable": {
-            "finish-args-flatpak-spawn-access": "Required to set up the host service for GPU control."
+            "finish-args-flatpak-spawn-access": "Required to set up the host service for GPU control.",
+            "finish-args-systemd1-system-talk-name": "Required to set up and manage the host service for GPU control."
         }
     },
     "io.github.insilmaril.vym": {


### PR DESCRIPTION
LACT requires a host service running as root to use most of the app's functionality.

There is already a permission for `flatpak-spawn --host` access to perform the setup of the service. In the latest update. the setup process has been improved, with in-app reporting of the service status among other things. This requires talking to systemd over DBus.