### PR TITLE
Add finish-args-flatpak-appdata-folder-org.chnapy.pkvault-ro-access exception for io.github.chnapy.pkvault

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3583,6 +3583,11 @@
             "finish-args-host-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.chnapy.pkvault": {
+        "stable": {
+            "finish-args-flatpak-appdata-folder-org.chnapy.pkvault-ro-access": "Migrate data from old PKVault version installed from flatpak file, required to avoid user data loss"
+        }
+    },
     "io.github.ciromattia.kcc": {
         "stable": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
This app is currently used as a flatpak file with an ID `org.chnapy.pkvault`.
To follow Flathub rules, I changed this ID to `io.github.chnapy.pkvault`, but to avoid user data loss I need to migrate data from old ID to new one.

Related Flathub PR: https://github.com/flathub/flathub/pull/9743