### PR TITLE
Add flathub-json-automerge-enabled exception for cn.eeo.ClassIn

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -277,7 +277,8 @@
     },
     "cn.eeo.ClassIn": {
         "stable": {
-            "finish-args-home-filesystem-access": "Needed because the proprietary Qt-based file picker cannot access through symlinks, and allow users to select files from the root of their home directory."
+            "finish-args-home-filesystem-access": "Needed because the proprietary Qt-based file picker cannot access through symlinks, and allow users to select files from the root of their home directory.",
+            "flathub-json-automerge-enabled":"Allow merging of autobot PRs to keep ClassIn updated (uses extra-data with external link)"
         }
     },
     "cn.ottercorp.xivlaunchercn": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -278,7 +278,7 @@
     "cn.eeo.ClassIn": {
         "stable": {
             "finish-args-home-filesystem-access": "Needed because the proprietary Qt-based file picker cannot access through symlinks, and allow users to select files from the root of their home directory.",
-            "flathub-json-automerge-enabled":"Allow merging of autobot PRs to keep ClassIn updated (uses extra-data with external link)"
+            "flathub-json-automerge-enabled": "Allow merging of autobot PRs to keep ClassIn updated (uses extra-data with external link)"
         }
     },
     "cn.ottercorp.xivlaunchercn": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -275,6 +275,11 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "cn.eeo.ClassIn": {
+        "stable": {
+            "finish-args-home-filesystem-access": "Needed because the proprietary Qt-based file picker cannot access through symlinks, and allow users to select files from the root of their home directory."
+        }
+    },
     "cn.ottercorp.xivlaunchercn": {
         "stable": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Hi Flathub reviewers, this exception is required for https://github.com/flathub/flathub/pull/9708 

**Why**
- This is a 3rd-party wrapper, and Classin is proprietary. 
- Because that, I used extra-data for ClassIn, and EEO use a repo that stays on their web, and I want to enable automatically flathubbot prs for the app can automatically update.

So can you review again and add this expection?
