### PR TITLE
Add exceptions to io.github.muchobliged.SimpleDoomLauncher

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4147,6 +4147,12 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.muchobliged.SimpleDoomLauncher": {
+        "stable": {
+            "finish-args-flatpak-spawn-access": "The app can launch Flatpak versions of Doom ports",
+            "finish-args-home-filesystem-access": "The app needs to be able to get access to files that weren't selected by user, like from config import"
+        }
+    },
     "io.github.muse_sequencer.Muse": {
         "stable": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
I would like to request exceptions for io.github.muchobliged.SimpleDoomLauncher

"finish-args-flatpak-spawn-access": Simple Doom Launcher can launch flatpak versions of Doom source ports, the permission is crucial for that

"finish-args-home-filesystem-access": Simple Doom Launcher has option to import configs that contain paths to files, Portal approach isn't suited here since paths written in configs can be anywhere. I used "--filesystem=home, --filesystem=/run/media, --filesystem=/media, --filesystem=/mnt" to cover as much places as possible where user could have mods(.wad, pk3 etc) installed

Simple Doom Launcher doesn't modify any files. When it scans folder it takes only files with Doom mods exctensions. Write access is needed for "launch as portable" option, where the app creates folder near the executable to set it as home directory

The request is for [this](https://github.com/flathub/flathub/pull/9771) pr