### PR TITLE
org.libreoffice.LibreOffice: make gtk config read-only

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -7574,7 +7574,7 @@
             "finish-args-host-filesystem-access": "Predates the linter rule",
             "finish-args-own-name-org.libreoffice.LibreOfficeIpc0": "Predates the linter rule",
             "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/111> 'GTK bookmarks do not appear in the flatpak version of LibreOffice'",
-            "finish-args-unnecessary-xdg-config-gtk-3.0-rw-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/136> 'fontconfig user configuration'"
+            "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "the app predates this linter rule, and this was added to fix <https://github.com/flathub/org.libreoffice.LibreOffice/issues/136> 'fontconfig user configuration'"
         }
     },
     "org.librepcb.LibrePCB": {


### PR DESCRIPTION
Granting rw access is common mistake as 99% of apps are fine with ro.

PR for LO: https://github.com/flathub/org.libreoffice.LibreOffice/pull/384