### PR TITLE
Add dev.fishies.godl exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2794,6 +2794,12 @@
             "finish-args-host-tmp-access": "Predates the linter rule"
         }
     },
+	"dev.fishies.godl": {
+        "stable": {
+            "finish-args-host-filesystem-access": "needed to access and modify projects outside of sandbox",
+			"finish-args-flatpak-spawn-access": "needed to spawn Godot"
+        }
+    },
     "dev.gbstudio.gb-studio": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
1. It was renamed from io.github.sockeye_d.godl to dev.fishies.godl
2. I now need flatpak-spawn-access because I spawn Godot outside of the sandbox; see https://github.com/flathub-infra/flatpak-builder-lint/pull/938#issuecomment-4149437530 for more information