### PR TITLE
Add exception for Bottles UMU runtimes sharing with host

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2432,7 +2432,7 @@
     },
     "com.usebottles.bottles": {
         "*": {
-            "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
+            "finish-args-contains-both-x11-and-wayland": "App uses Wayland, and wine installations inside of it can use X11",
             "module-vmtouch-checker-tracks-commits": "Module is unmaintained for 2 years",
             "finish-args-unnecessary-xdg-data-umu-create-access": "Uses shared installation for the umu runtime"
         }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2433,7 +2433,8 @@
     "com.usebottles.bottles": {
         "*": {
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule",
-            "module-vmtouch-checker-tracks-commits": "Module is unmaintained for 2 years"
+            "module-vmtouch-checker-tracks-commits": "Module is unmaintained for 2 years",
+            "finish-args-unnecessary-xdg-data-umu-create-access": "Uses shared installation for the umu runtime"
         }
     },
     "com.usebruno.Bruno": {


### PR DESCRIPTION
Follows the same path as Lutris and Heroic Launchers as both have this same exception here.

Complementing PR to enable it in Bottles flatpak manifest: https://github.com/flathub/com.usebottles.bottles/pull/548