### PR TITLE
Add moe.nomm.Nomm exceptions for file access

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8777,5 +8777,12 @@
         "stable": {
             "finish-args-host-var-access": "Required to connect to wireless devices, usbmuxd doesn't handle/recognize wireless devices on Linux and Windows."
         }
-    }
+    },
+	"moe.nomm.Nomm": {
+    	"stable": {
+        	"finish-args-flatpak-appdata-folder-com.valvesoftware.Steam-rw-access": "Required to be able to mod games on Steam's Flatpak version.",
+			"finish-args-flatpak-appdata-folder-com.heroicgameslauncher.hgl-config-heroic-ro-access": "Required to be able to mod games on Heroic's Flatpak version.",
+			"finish-args-flatpak-appdata-folder-io.github.ryubing.Ryujinx-config-Ryujinx-rw-access": "Required to be able to mod games on Ryubing's Flatpak Version."
+    	}
+	}
 }


### PR DESCRIPTION
To mod games on different platforms, my app needs to have access to different game platforms' Flatpak directories.
The app also has access to non-flatpak versions of the same platforms.

Here is NOMM's more detailed workflow:
1. Config files are read from Steam/Heroic to get the list of locations for game libraries
2. Once I know where the libraries are located, I generate a command that the user can copy and paste into console, to give app the rights to install mods in those directories (in which I need write access).
3. User then has to restart NOMM so that the new permissions take effect
4. I can now deploy mods via symlinks to the user's libraries

The reason I need write access to Steam (and not just read-only) is because NOMM also comes with a feature to change the game's launch options for the user, which requires writing to steam config files.

The reason I need write access to Ryubing is because that is where the mods need to be deployed (for switch emulation, mods are not stored in game files but instead in emulator files), so there is no point in first requesting read-only and then write, because I know I will need write to that location anyway.

Please keep in mind that I will very likely implement the same feature I have for Steam on Heroic as well, so I will need to switch from `ro` to `rw` there as well in the future.