### PR TITLE
Add exception for Butler to restart itself

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -490,7 +490,7 @@
     },
     "com.cassidyjames.butler": {
         "stable": {
-            "flathub-json-automerge-enabled": "Predates the linter rule"
+            "finish-args-flatpak-spawn-access": "Required to restart itself after changing hardware acceleration settings"
         }
     },
     "com.cassidyjames.plausible": {


### PR DESCRIPTION
1.8.0 is adding a hardware acceleration setting, and for a good experience, the app prompts to restart itself. Afaiui this requires using `flatpak-spawn` to relaunch itself.

Removed the unused automerge exception as long as I was here.