### PR TITLE
Add COSMIC theme exception for io.github.marcelogomes90.FileCrate

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4059,6 +4059,11 @@
             "finish-args-own-name-wildcard-org.gnome.gimagereader": "Predates the linter rule"
         }
     },
+    "io.github.marcelogomes90.FileCrate": {
+        "stable": {
+            "finish-args-unnecessary-xdg-config-cosmic-ro-access": "File Crate is a libcosmic application and requires read-only access to the host's ~/.config/cosmic directory to follow the host COSMIC theme; without this permission, the Flatpak falls back to an incorrect theme."
+        }
+    },
     "io.github.marco_calautti.DeltaPatcher": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
This adds a stable exception for `io.github.marcelogomes90.FileCrate`.

File Crate is a native libcosmic application. Its Flatpak requires read-only access to `~/.config/cosmic` to follow the host COSMIC theme. I tested the application without this permission, but it no longer matched the host theme.

Related Flathub submission: https://github.com/flathub/flathub/pull/9869