### PR TITLE
Add host filesystem exception for io.github.marcelogomes90.FileCrate

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4059,6 +4059,11 @@
             "finish-args-own-name-wildcard-org.gnome.gimagereader": "Predates the linter rule"
         }
     },
+    "io.github.marcelogomes90.FileCrate": {
+        "stable": {
+            "finish-args-host-filesystem-access": "File Crate is an archive manager: it opens, creates and extracts archives wherever the user keeps them, and receives plain host paths from Wayland drag-and-drop that the document portal never exported and the file chooser portal cannot cover. Host access also keeps large archives off the document portal's FUSE mount, which otherwise dominates the cost of every read and write."
+        }
+    },
     "io.github.marco_calautti.DeltaPatcher": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
This adds a stable exception for io.github.marcelogomes90.FileCrate.

File Crate is an archive manager. Its requires host filesystem access because Wayland drag-and-drop delivers plain host paths that the document portal has never exported, and the file chooser portal cannot cover that case. I tested the application without this permission, but dropping an archive onto the window always failed, and the properties panel showed a /run/user/1000/doc/ path instead of the real archive location.

Reading and writing large archives through the document portal's FUSE mount is also noticeably slower than working on the real paths.