### PR TITLE
exceptions: io.github.yelanxin.OxiTide — own-name org.freedesktop.ReserveDevice1.*

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -4709,6 +4709,11 @@
             "finish-args-host-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.yelanxin.OxiTide": {
+        "*": {
+            "finish-args-own-name-wildcard-org.freedesktop.ReserveDevice1": "ALSA direct output uses the freedesktop ReserveDevice1 protocol: the app owns org.freedesktop.ReserveDevice1.Audio<card> to take a sound card exclusively from PipeWire/PulseAudio"
+        }
+    },
     "io.github.yuxshao.ptcollab": {
         "stable": {
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
OxiTide (Flathub submission flathub/flathub#9878) drives sound cards directly over
ALSA (hw:) and uses the freedesktop ReserveDevice1 protocol to take a card from
PipeWire/PulseAudio: it owns org.freedesktop.ReserveDevice1.Audio<card index> on the
session bus and asks the current holder to release the card. The bus name is
per-card, hence the wildcard own-name.