### PR TITLE
Add io.github.heri_anggara.GitBraid exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -3871,6 +3871,12 @@
             "finish-args-home-filesystem-access": "Predates the linter rule"
         }
     },
+    "io.github.heri_anggara.GitBraid": {
+        "*": {
+            "finish-args-has-socket-ssh-auth": "Needed to fetch, pull and push over SSH remotes",
+            "finish-args-home-filesystem-access": "Version control tool requiring direct access to user-chosen project directories"
+        }
+    },
     "io.github.hkdb.Aerion": {
         "stable": {
             "finish-args-login1-system-talk-name": "Aerion as an email client needs to detect system sleep/wake via logind to trigger immediate mail sync after resume"


### PR DESCRIPTION
GitBraid is a Git client for Linux, submitted to Flathub in flathub/flathub#9887. The test build fails at `validate-manifest` on these two, and neither can be dropped without breaking what the application is for.

**`finish-args-has-socket-ssh-auth`** — fetch, pull and push over SSH remotes, through the agent the desktop already runs. The application sets `GIT_TERMINAL_PROMPT=0`, so it cannot fall back to prompting, and every SSH remote simply fails without this. Same reason as `io.github.sourcegit_scm.sourcegit`, `io.github.pol_rivero.github-desktop-plus` and `com.gitbutler.gitbutler`.

**`finish-args-home-filesystem-access`** — a git client is pointed at whichever repositories the reader chooses and must keep reading them (status, log, diffs, refs) for the length of a session. No portal covers that: the file chooser hands over one document at a time, and a repository is a directory whose contents change while the application watches it. It also reads `~/.gitconfig`, which is where git itself takes the user's identity from. Same reason as `com.clustta.clustta`.

`"*"` rather than `"stable"` because the submission's test build runs against `flathub/test`, and `get_local_exceptions` unions the repo key with `"*"` — a `"stable"` key alone would leave the test build failing. `io.github.sourcegit_scm.sourcegit` uses `"*"` for the same reason.

`utils/validator.py` passes.