### PR TITLE
exceptions: Add another exception to cx.modal.TestCenter

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2610,6 +2610,7 @@
             "finish-args-flatpak-appdata-folder-rw-access": "Needs access to user data of other apps to remove leftover data",
             "finish-args-flatpak-system-talk-name": "Talks to the system-wide flatpak dbus address in order to query existence of flatpaks and send installation commands to it",
             "finish-args-flatpak-spawn-access": "Required to run systemd-sysext and related tools on the host",
+            "finish-args-host-var-access": "Required to read /var/lib/extensions to look at sysexts on the host",
             "finish-args-unnecessary-xdg-data-flatpak-rw-access": "Needs access to user-wide flatpak installation to list and manage apps",
             "finish-args-flatpak-system-folder-rw-access": "Needs access to system-wide flatpak installation to list and manage apps"
         }


### PR DESCRIPTION
Turns out "finish-args-host-var-access" is needed after all because we access /var/lib/extensions from within the sandbox.