### PR TITLE
exceptions: add finish-args-contains-both-x11-and-wayland for Git Cola

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1045,6 +1045,7 @@
     "com.github.git_cola.git-cola": {
         "stable": {
             "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+            "finish-args-contains-both-x11-and-wayland": "Needed for gitk subprocesses",
             "finish-args-has-socket-gpg-agent": "Predates the linter rule",
             "finish-args-has-socket-ssh-auth": "Predates the linter rule",
             "finish-args-home-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
Git Cola (Qt) needs `--socket=wayland`.
Gitk can be launched as a subprocess, and needs `--socket=x11`.

Related-to: https://github.com/flathub/com.github.git_cola.git-cola/issues/124