### PR TITLE
Restore login1 exception for com.github.IsmaelMartinez.teams_for_linux

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -741,7 +741,8 @@
     "com.github.IsmaelMartinez.teams_for_linux": {
         "*": {
             "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-            "finish-args-home-filesystem-access": "Predates the linter rule"
+            "finish-args-home-filesystem-access": "Predates the linter rule",
+            "finish-args-login1-system-talk-name": "Electron's powerMonitor needs PrepareForSleep from login1 for its resume handlers; no portal exposes this signal."
         }
     },
     "com.github.KRTirtho.Spotube": {


### PR DESCRIPTION
The `finish-args-login1-system-talk-name` exception for `com.github.IsmaelMartinez.teams_for_linux` was removed by the automated stale-exception purge in #1134, but the permission is still in active use, so this restores it.

`--system-talk-name=org.freedesktop.login1` is present in both the `master` and `beta` manifests of the packaging repo today. Electron's `powerMonitor` needs the `PrepareForSleep` signal from login1 for its suspend and resume handlers, and no portal exposes that signal, so the app cannot drop the permission. The exception was originally added in b45ff0fe and widened to the `*` key in 2e0a89aa.

This surfaced on flathub/com.github.IsmaelMartinez.teams_for_linux#222, where `validate-manifest` now fails with `'finish-args-login1-system-talk-name' error found in linter manifest check` before the build stages run. The wording is unchanged from the original entry.
