### PR TITLE
Exception: finish-args-contains-both-x11-and-wayland for dev.eden_eden_emu

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2775,6 +2775,11 @@
             "finish-args-unnecessary-xdg-config-gtk-3.0-ro-access": "needs access to xdg-config/gtk-3.0 for theming, does not support portals"
         }
     },
+    "dev.eden_emu.eden": {
+        "stable": {
+            "finish-args-contains-both-x11-and-wayland": "Required to use the x11 backend without crashing",
+        }
+    },
     "dev.edfloreshz.Calculator": {
         "stable": {
             "finish-args-unnecessary-xdg-config-cosmic-rw-access": "Required to listen for changes in the host and write app configuration files"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -2777,7 +2777,7 @@
     },
     "dev.eden_emu.eden": {
         "stable": {
-            "finish-args-contains-both-x11-and-wayland": "Required to use the x11 backend without crashing",
+            "finish-args-contains-both-x11-and-wayland": "Required to use the x11 backend without crashing"
         }
     },
     "dev.edfloreshz.Calculator": {


### PR DESCRIPTION
If a user chooses to use the x11 backend, it crashes without explicit x11 socket permission.