### PR TITLE
exceptions: add finish-args-login1-system-talk-name for com.onekeepass.OneKeePass

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8795,5 +8795,10 @@
             "finish-args-home-filesystem-access": "Required for correct execution of UMU-launcher and Proton, and for access to user configurations.",
             "finish-args-contains-both-x11-and-wayland": "Without X11, errors occur when launching some games."
         }
+    },
+    "com.onekeepass.OneKeePass": {
+        "stable": {
+            "finish-args-login1-system-talk-name": "Takes a logind delay inhibitor and listens for PrepareForSleep to encrypt the open database's decrypted content before the system suspends, so a hibernation image cannot contain plaintext secrets. There is no portal equivalent: the Inhibit portal can block a suspend but gives no notification that one is starting."
+        }
     }
 }


### PR DESCRIPTION
Requesting one exception for a new app submission: flathub/flathub#10032

**App:** OneKeePass — an offline, KeePass-compatible (KDBX 4) password manager.
GPL-3.0-or-later. https://github.com/OneKeePass/desktop

**Rule:** `finish-args-login1-system-talk-name`

This exception is required for the reason:

The app takes a logind delay inhibitor and listens for `PrepareForSleep` so that an open database's decrypted content is encrypted before the system suspends. Without it, a machine that hibernates while a database is unlocked can write a memory image containing plaintext secrets to disk

There is  no portal equivalent.`org.freedesktop.portal.Inhibit` can *block* a suspend, and `CreateMonitor` reports session state, but neither provides a notification that a suspend is starting, which is the signal this needs. It uses the system bus (`Connection::system()`), which the sandbox does not provide by default.

