### PR TITLE
exceptions: add finish-args-contains-both-x11-and-wayland for org.dpsoftware.FireflyLuciferin

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5877,7 +5877,8 @@
     },
     "org.dpsoftware.FireflyLuciferin": {
         "stable": {
-            "finish-args-kwin-talk-name": "Predates the linter rule"
+            "finish-args-kwin-talk-name": "Used for StatusNotifierItem/AppIndicator and to detect NightLight status via DBUS.",
+            "finish-args-contains-both-x11-and-wayland": "JavaFX requires X11, GStreamer along with Pipewiresrc requires Wayland."
         }
     },
     "org.dune3d.dune3d": {


### PR DESCRIPTION
Requesting exception for `finish-args-contains-both-x11-and-wayland`

Firefly Luciferin genuinely requires both `--socket=x11` and `--socket=wayland` the app is unusable without either, confirmed via flatpak override testing:

Without X11 (--nosocket=x11, Wayland only): JavaFX/Glass fails to start entirely it has no native Wayland backend and always initializes through XWayland, even in a pure Wayland session:

```
Exception in thread "main" java.lang.UnsupportedOperationException: Unable to open DISPLAY
    at com.sun.glass.ui.gtk.GtkApplication.<init>(GtkApplication.java:153)
    at com.sun.glass.ui.gtk.GtkPlatformFactory.createApplication(GtkPlatformFactory.java:40)
    at com.sun.glass.ui.Application.run(Application.java:143)
    at com.sun.javafx.tk.quantum.QuantumToolkit.startup(QuantumToolkit.java:289)
    at com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:281)
    ...
```

Without Wayland (--nosocket=wayland, X11 only): screen capture via PipeWire (pipewiresrc) fails to negotiate a supported buffer format and the pipeline errors out:

```
WARN pipewiresrc gstpipewiresrc.c:929:on_state_changed:<pipewiresrc0> error: stream error: no more input formats
WARN basesrc gstbasesrc.c:3187:gst_base_src_loop:<pipewiresrc0> error: Internal data stream error.
WARN basesrc gstbasesrc.c:3187:gst_base_src_loop:<pipewiresrc0> error: streaming stopped, reason not-negotiated (-4)
```

This is the app's core function (screen capture for ambient LED lighting), so it's not an optional feature we can gate behind X11-only support.

We tested dropping each socket individually (not just removing both) and confirmed each failure mode above with flatpak override --user. 

I commit to removing the x11 socket and keeping only the fallback-x11 socket as soon as JavaFX supports the Wayland backend.

Happy to provide further logs or test additional configurations if useful for review.