### PR TITLE
exceptions: finish-args-flatpak-appdata-folder-org.onlyoffice.desktopeditors-data-onlyoffice-desktopeditors-recover-ro-access for page.wisha.platen

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8487,6 +8487,11 @@
             "finish-args-unnecessary-xdg-config-dconf-rw-access": "needed to access host dconf configuration at launch time"
         }
     },
+    "page.wisha.platen": {
+        "stable": {
+            "finish-args-flatpak-appdata-folder-org.onlyoffice.desktopeditors-data-onlyoffice-desktopeditors-recover-ro-access": "Required so equations in OnlyOffice can be pasted back to Platen to recover formula"
+        }
+    },
     "party.supertux.supertuxparty": {
         "stable": {
             "finish-args-contains-both-x11-and-wayland": "Predates the linter rule"


### PR DESCRIPTION
App submission PR: https://github.com/flathub/flathub/pull/10041.

When you copy an image object in OnlyOffice, the clipboard data contain a link to the location where OnlyOffice store the actual file. Platen needs to access these files, so that when users paste equations from OnlyOffice to Platen we can recover the formula.