### PR TITLE
Add exception for com.inochi2d.inochi-session

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1773,6 +1773,11 @@
             "flathub-json-automerge-enabled": "Predates the linter rule"
         }
     },
+    "com.inochi2d.inochi-session": {
+        "*": {
+            "finish-args-home-filesystem-access": "Append or modify tracking configuration to model files"
+        }
+    },
     "com.interversehq.qView": {
         "stable": {
             "finish-args-host-filesystem-access": "Predates the linter rule"


### PR DESCRIPTION
This exception is needed so that the packaged version of the application is able to save the tracking configuration into the opened model file.