### PR TITLE
Add finish-args exception for Proton Pass

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8800,5 +8800,5 @@
         "*": {
             "finish-args-contains-both-x11-and-wayland": "X11 access is needed for clipboard access"
         }
-    },
+    }
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8798,7 +8798,7 @@
     },
     "me.proton.Pass": {
         "*": {
-            "finish-args-contains-both-x11-and-wayland": "X11 access is needed for clipboard access",
+            "finish-args-contains-both-x11-and-wayland": "X11 access is needed for clipboard access"
         }
     },
 }

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8795,5 +8795,10 @@
             "finish-args-home-filesystem-access": "Required for correct execution of UMU-launcher and Proton, and for access to user configurations.",
             "finish-args-contains-both-x11-and-wayland": "Without X11, errors occur when launching some games."
         }
-    }
+    },
+    "me.proton.Pass": {
+        "*": {
+            "finish-args-contains-both-x11-and-wayland": "X11 access is needed for clipboard access",
+        }
+    },
 }


### PR DESCRIPTION
Related: https://github.com/flathub/me.proton.Pass/issues/37

Similar to Bitwarden, Proton Pass uses the same arboard library, so it can perform the essential function of **copying**, which requires x11 in Flatpak, whereas the main Electron application requires Wayland