### PR TITLE
Add desktop-file-is-nodisplay entry to fcitx

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -5965,7 +5965,8 @@
             "finish-args-unnecessary-xdg-config-fcitx-create-access": "need for simulating ibus daemon and changing kde system xkb settings",
             "finish-args-unnecessary-xdg-config-fontconfig-ro-access": "Predates the linter rule",
             "finish-args-unnecessary-xdg-config-ibus-create-access": "Predates the linter rule",
-            "finish-args-unnecessary-xdg-config-kxkbrc-rw-access": "Predates the linter rule"
+            "finish-args-unnecessary-xdg-config-kxkbrc-rw-access": "Predates the linter rule",
+            "desktop-file-is-nodisplay": "Input method doesn't need to show in menu"
         }
     },
     "org.fedoraproject.MediaWriter": {


### PR DESCRIPTION
Setting NoDisplay It's a request from KDE upstream: https://invent.kde.org/kde-linux/kde-linux/-/work_items/743

It seems to make sense to me because input method is a thing that user doesn't start manually from menu, even though there's GUI. However desktop file is still required to set certain metadata field to allow KDE to display it in another place and grant required permission.

I'm aware that doc says this is never granted but maybe this is still a meaningful case: https://docs.flathub.org/docs/for-app-authors/linter#desktop-file-is-nodisplay

Outside the flatpak world,

E.g. https://github.com/ibus/ibus/blob/main/ui/gtk3/ibus-ui-wayland.desktop.in , ibus also Set NoDisplay=true in their desktop file
