### PR TITLE
Update exceptions for page.codeberg.JakobDev.jdAppStreamEdit

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -8357,7 +8357,7 @@
     },
     "page.codeberg.JakobDev.jdAppStreamEdit": {
         "stable": {
-            "finish-args-flatpak-spawn-access": "required for preview in Gnome Software"
+            "finish-args-host-tmp-access": "Needs to share files with programs outside the Sandbox"
         }
     },
     "page.codeberg.JakobDev.jdDBusDebugger": {


### PR DESCRIPTION
GNOME Software has now a desktop entry for previewing AppStream files, so [I can use the OpenURI Portal](https://codeberg.org/JakobDev/jdAppStreamEdit/commit/6111ab06fc601d69aba663f465fc93fba4db904b) rather than the command line. However, due to flatpak/xdg-desktop-portal#1744 access to `/tmp` is needed to make it work.

This is needed to merge flathub/page.codeberg.JakobDev.jdAppStreamEdit#209.